### PR TITLE
feat: data_changed WebSocket listener for real-time UI updates

### DIFF
--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -276,7 +276,7 @@ export interface WsIncomingGlobalChat {
 
 export interface WsDataChanged {
   type: "data_changed";
-  entity: "pipeline" | "step";
+  entity: "pipeline" | "step" | "skill";
   action: "created" | "updated" | "deleted";
   id: string;
 }

--- a/server/src/services/tools/create-skill-script.ts
+++ b/server/src/services/tools/create-skill-script.ts
@@ -89,6 +89,7 @@ export function makeCreateSkillScript(ctx: AgentToolContext): ToolDefinition {
       }
 
       writeFileSync(scriptPath, params.content, "utf-8");
+      ctx.broadcastDataChanged("skill", "updated", params.skillName);
       return { content: [{ type: "text" as const, text: `Created script "${params.filename}" in skill "${params.skillName}".` }], details: {} };
     },
   };

--- a/server/src/services/tools/create-skill.ts
+++ b/server/src/services/tools/create-skill.ts
@@ -97,6 +97,7 @@ Keep under 500 lines. Avoid restating general LLM knowledge.`,
         metadata: params.metadata,
       });
       writeFileSync(join(skillDir, "SKILL.md"), content, "utf-8");
+      ctx.broadcastDataChanged("skill", "created", params.skillName);
       return { content: [{ type: "text" as const, text: `Created skill "${params.skillName}" at ${skillDir}.` }], details: {} };
     },
   };

--- a/server/src/services/tools/delete-skill-script.ts
+++ b/server/src/services/tools/delete-skill-script.ts
@@ -29,6 +29,7 @@ export function makeDeleteSkillScript(ctx: AgentToolContext): ToolDefinition {
       }
 
       rmSync(scriptPath);
+      ctx.broadcastDataChanged("skill", "updated", params.skillName);
       return { content: [{ type: "text" as const, text: `Deleted script "${params.filename}" from skill "${params.skillName}".` }], details: {} };
     },
   };

--- a/server/src/services/tools/update-skill-script.ts
+++ b/server/src/services/tools/update-skill-script.ts
@@ -70,6 +70,7 @@ export function makeUpdateSkillScript(ctx: AgentToolContext): ToolDefinition {
       }
 
       writeFileSync(scriptPath, params.content, "utf-8");
+      ctx.broadcastDataChanged("skill", "updated", params.skillName);
       return { content: [{ type: "text" as const, text: `Updated script "${params.filename}" in skill "${params.skillName}".` }], details: {} };
     },
   };

--- a/server/src/services/tools/update-skill.ts
+++ b/server/src/services/tools/update-skill.ts
@@ -117,6 +117,7 @@ Replaces the existing body entirely. Keep under 500 lines.`,
       });
 
       writeFileSync(skillPath, content, "utf-8");
+      ctx.broadcastDataChanged("skill", "updated", params.skillName);
       return { content: [{ type: "text" as const, text: `Updated skill "${params.skillName}".` }], details: {} };
     },
   };

--- a/ui/src/components/GlobalChatPanel.tsx
+++ b/ui/src/components/GlobalChatPanel.tsx
@@ -1,6 +1,5 @@
 import { useState, useRef, useEffect } from "react";
 import { useNavigate, useLocation } from "react-router-dom";
-import { useQueryClient } from "@tanstack/react-query";
 import { RotateCcw, Send, StopCircle, X } from "lucide-react";
 import ReactMarkdown from "react-markdown";
 import { useWebSocket } from "../lib/ws.ts";
@@ -36,18 +35,7 @@ export default function GlobalChatPanel({ onClose }: GlobalChatPanelProps) {
   const inputRef = useRef<HTMLInputElement>(null);
   const navigate = useNavigate();
   const location = useLocation();
-  const queryClient = useQueryClient();
-
   const { send: wsSend } = useWebSocket((msg: WsMessage) => {
-    if (msg.type === "data_changed") {
-      if (msg.entity === "pipeline") {
-        queryClient.invalidateQueries({ queryKey: ["pipelines"] });
-        queryClient.invalidateQueries({ queryKey: ["pipeline"] });
-      }
-      if (msg.entity === "step") queryClient.invalidateQueries({ queryKey: ["pipeline"] });
-      return;
-    }
-
     if (msg.type !== "global_agent_event") return;
 
     if (msg.eventType === "text_delta" && msg.message) {

--- a/ui/src/components/Layout.tsx
+++ b/ui/src/components/Layout.tsx
@@ -31,6 +31,7 @@ import { useQuery } from "@tanstack/react-query";
 import type { ReactNode } from "react";
 import { api } from "../lib/api.ts";
 import GlobalChatPanel from "./GlobalChatPanel.tsx";
+import { useDataChangedListener } from "../hooks/useDataChangedListener.ts";
 
 function ApprovalsNavItem() {
   const { data: pending = [] } = useQuery({
@@ -82,6 +83,7 @@ const bottomNav = [
 ];
 
 export default function Layout({ children }: { children: ReactNode }) {
+  useDataChangedListener();
   const [agentOpen, setAgentOpen] = useState(false);
   const [agentWidth, setAgentWidth] = useState(384); // 96 * 4 = w-96 default
   const isDragging = useRef(false);

--- a/ui/src/hooks/useDataChangedListener.ts
+++ b/ui/src/hooks/useDataChangedListener.ts
@@ -1,0 +1,26 @@
+import { useQueryClient } from "@tanstack/react-query";
+import { useWebSocket } from "../lib/ws.ts";
+import type { WsMessage } from "@zerohand/shared";
+
+/** Listens for data_changed WS events and invalidates React Query caches. */
+export function useDataChangedListener() {
+  const queryClient = useQueryClient();
+
+  useWebSocket((msg: WsMessage) => {
+    if (msg.type !== "data_changed") return;
+
+    switch (msg.entity) {
+      case "pipeline":
+        queryClient.invalidateQueries({ queryKey: ["pipelines"] });
+        queryClient.invalidateQueries({ queryKey: ["pipeline"] });
+        break;
+      case "step":
+        queryClient.invalidateQueries({ queryKey: ["pipeline"] });
+        break;
+      case "skill":
+        queryClient.invalidateQueries({ queryKey: ["skills"] });
+        queryClient.invalidateQueries({ queryKey: ["skill"] });
+        break;
+    }
+  });
+}


### PR DESCRIPTION
## Summary
Closes #32

- Extract `data_changed` WebSocket handling from GlobalChatPanel into a dedicated `useDataChangedListener` hook mounted in Layout (always active)
- Extend `WsDataChanged` entity type to include `"skill"` alongside `"pipeline"` and `"step"`
- Add `broadcastDataChanged` calls to all 5 skill agent tools (create, update, script create/update/delete)

## What changed
- **`packages/shared`**: Added `"skill"` to `WsDataChanged.entity` union
- **`server/src/services/tools/`**: 5 skill tools now broadcast `data_changed` events
- **`ui/src/hooks/useDataChangedListener.ts`**: New hook — invalidates React Query caches on `data_changed` for pipelines, steps, and skills
- **`ui/src/components/Layout.tsx`**: Mounts the hook at app level
- **`ui/src/components/GlobalChatPanel.tsx`**: Removed duplicated handling and unused `useQueryClient`

## Test plan
- [ ] Typecheck passes (`pnpm typecheck`) 
- [ ] All 95 tests pass (`pnpm test`)
- [ ] Full build succeeds (`pnpm build`)
- [ ] Agent creates a pipeline → Pipelines page updates without refresh
- [ ] Agent modifies a skill → Skills page updates without refresh
- [ ] Close chat panel → invalidation still fires (hook in Layout)
- [ ] RunDetail streaming still works (existing WS handlers unaffected)