### PR TITLE
Add WebSocket broadcasts to budgets, packages, and triggers routes

### DIFF
--- a/docs/plans/2026-04-04-002-feat-ws-broadcasts-routes-plan.md
+++ b/docs/plans/2026-04-04-002-feat-ws-broadcasts-routes-plan.md
@@ -1,0 +1,200 @@
+---
+title: "feat: Add WebSocket broadcasts to budgets, packages, and triggers routes"
+type: feat
+status: completed
+date: 2026-04-04
+---
+
+# feat: Add WebSocket broadcasts to budgets, packages, and triggers routes
+
+## Overview
+
+Add `data_changed` WebSocket broadcasts to every CREATE/UPDATE/DELETE mutation in the budgets, packages, and triggers route handlers. Currently these routes mutate silently — no other client knows about changes until a page refresh.
+
+## Problem Frame
+
+The approvals route already broadcasts `data_changed` events via `WsManager`, enabling real-time UI updates. The budgets, packages, and triggers routes lack this integration, creating an inconsistent experience where some mutations update the UI in real-time and others do not.
+
+## Requirements Trace
+
+- R1. Pass `WsManager` to `createBudgetsRouter`, `createPackagesRouter`, and `createTriggersRouter` in `server/src/index.ts`
+- R2. Broadcast `{ type: "data_changed", entity, action, id }` on every CREATE/UPDATE/DELETE mutation in all three routes
+- R3. Extend `WsDataChanged` entity union to include `"trigger"`, `"budget"`, `"package"` (if PR #49 hasn't merged first)
+- R4. Verify: UI pages refresh when another client modifies these entities
+
+## Scope Boundaries
+
+- Only modifying existing route handlers — no new routes
+- No changes to the UI WebSocket listener (issue #32 covers that separately)
+- No changes to the WsManager class itself
+- Read-only routes (GET) are not affected
+
+## Context & Research
+
+### Relevant Code and Patterns
+
+- **Pattern to follow**: `server/src/routes/approvals.ts` — already receives `WsManager` and calls `ws.broadcast({ type: "run_status", ... })`. Note: approvals broadcasts `run_status`, not `data_changed`. Use the `WsDataChanged` type definition in `packages/shared/src/index.ts` as the authoritative reference for the `data_changed` broadcast payload shape, and approvals only for the wiring pattern (how `ws` is received as a parameter)
+- **Route wiring**: `server/src/index.ts` — `createApprovalsRouter(db, ws)` is the pattern (registered after `WsManager` creation at line 162); the other three are currently registered at lines 141-148 (before `ws` exists) and receive only `(db)`. **Route registrations must be moved after `WsManager` creation.**
+- **WsManager**: `server/src/ws/index.ts` — `broadcast(msg)` method sends to all connected clients
+- **WsDataChanged type**: `packages/shared/src/index.ts` — entity union currently `"pipeline" | "step" | "skill"` on main
+
+### Institutional Learnings
+
+- `docs/solutions/best-practices/adding-agent-tools-dual-system-architecture-2026-04-04.md` — documents the pattern for extending `WsDataChanged` entity union
+
+## Key Technical Decisions
+
+- **Add `ws` parameter to existing route factory signatures**: Matches the approvals pattern. The `WsManager` import is from `server/src/ws/index.js`.
+- **Broadcast after successful mutation, not before**: The route handler should complete the DB write and have the row before broadcasting. This matches the approvals pattern.
+- **Use `ws.broadcast()` directly, not a helper**: The approvals route calls `ws.broadcast({ type: "data_changed", ... })` inline — follow the same approach for consistency.
+
+## Open Questions
+
+### Resolved During Planning
+
+- **Should we depend on PR #49 for the entity union extension?** No — include it in this plan for independence. If #49 merges first, this becomes a no-op for that step (the types are already extended).
+
+### Deferred to Implementation
+
+- None — this is straightforward pattern-following work.
+
+## Implementation Units
+
+- [ ] **Unit 1: Extend WsDataChanged entity union (if needed)**
+
+**Goal:** Ensure `"trigger"`, `"budget"`, and `"package"` are valid entity values in the `WsDataChanged` type.
+
+**Requirements:** R3
+
+**Dependencies:** None
+
+**Files:**
+- Modify: `packages/shared/src/index.ts`
+
+**Approach:**
+- Check if `WsDataChanged.entity` already includes the new values (PR #49 may have merged)
+- If not, add `"trigger" | "budget" | "package"` to the union
+- If `"setting"` and `"approval"` are also missing, add them for completeness (matching #49)
+
+**Patterns to follow:**
+- Existing `WsDataChanged` type definition
+
+**Test scenarios:**
+- Test expectation: none — pure type extension with no behavioral change
+
+**Verification:**
+- TypeScript compiles with no errors
+
+- [ ] **Unit 2: Add WsManager to triggers route**
+
+**Goal:** Broadcast `data_changed` on trigger create, update, and delete.
+
+**Requirements:** R1, R2
+
+**Dependencies:** Unit 1
+
+**Files:**
+- Modify: `server/src/routes/triggers.ts`
+- Modify: `server/src/index.ts`
+
+**Approach:**
+- Change `createTriggersRouter(db: Db)` signature to `createTriggersRouter(db: Db, ws: WsManager)`
+- Add `ws.broadcast({ type: "data_changed", entity: "trigger", action: "created", id: row.id })` after POST handler's `res.status(201).json()`
+- Add broadcast with action `"updated"` after PATCH handler's `res.json()`
+- Add broadcast with action `"deleted"` after DELETE handler's `res.status(204).send()`
+- Update `server/src/index.ts`: move triggers route registration after `WsManager` creation (line 162+) and change to `createTriggersRouter(db, ws)`
+
+**Patterns to follow:**
+- `server/src/routes/approvals.ts` — how `ws` is received and `ws.broadcast()` is called
+
+**Test scenarios:**
+- Happy path: creating a trigger broadcasts `{ type: "data_changed", entity: "trigger", action: "created", id }` 
+- Happy path: updating a trigger broadcasts with action `"updated"`
+- Happy path: deleting a trigger broadcasts with action `"deleted"`
+- Edge case: failed mutation (404 on update/delete) does NOT broadcast
+
+**Verification:**
+- Trigger CRUD operations produce WebSocket messages observable in the browser console
+
+- [ ] **Unit 3: Add WsManager to budgets route**
+
+**Goal:** Broadcast `data_changed` on budget create, update, and delete.
+
+**Requirements:** R1, R2
+
+**Dependencies:** Unit 1
+
+**Files:**
+- Modify: `server/src/routes/budgets.ts`
+- Modify: `server/src/index.ts`
+
+**Approach:**
+- Change `createBudgetsRouter(db: Db)` to `createBudgetsRouter(db: Db, ws: WsManager)`
+- Add broadcasts after POST (created), PATCH (updated), DELETE (deleted)
+- Update `server/src/index.ts`: move budgets route registration after `WsManager` creation and change to `createBudgetsRouter(db, ws)`
+
+**Patterns to follow:**
+- Same as Unit 2
+
+**Test scenarios:**
+- Happy path: creating a budget broadcasts with entity `"budget"`, action `"created"`
+- Happy path: updating a budget broadcasts with action `"updated"`
+- Happy path: deleting a budget broadcasts with action `"deleted"`
+- Edge case: 404 responses do NOT broadcast
+
+**Verification:**
+- Budget mutations produce `data_changed` WebSocket messages
+
+- [ ] **Unit 4: Add WsManager to packages route**
+
+**Goal:** Broadcast `data_changed` on package install, update, uninstall, and local-install.
+
+**Requirements:** R1, R2
+
+**Dependencies:** Unit 1
+
+**Files:**
+- Modify: `server/src/routes/packages.ts`
+- Modify: `server/src/index.ts`
+
+**Approach:**
+- Change `createPackagesRouter(db: Db)` to `createPackagesRouter(db: Db, ws: WsManager)`
+- Broadcast after: POST /packages/install (created), POST /packages/:id/update (updated), DELETE /packages/:id (deleted), POST /packages/install-local (created), POST /packages/publish (created)
+- Do NOT broadcast on read-only operations: GET /packages, GET /packages/discover, POST /packages/scan, GET /packages/:id/security, POST /packages/check-updates, POST /packages/export
+- Update `server/src/index.ts`: move packages route registration after `WsManager` creation and change to `createPackagesRouter(db, ws)`
+
+**Patterns to follow:**
+- Same as Units 2-3
+
+**Test scenarios:**
+- Happy path: installing a package broadcasts with entity `"package"`, action `"created"`
+- Happy path: updating a package broadcasts with action `"updated"`
+- Happy path: uninstalling a package broadcasts with action `"deleted"`
+- Happy path: local-install broadcasts with action `"created"`
+- Happy path: publish broadcasts with action `"created"`
+- Edge case: scan, discover, export, check-updates do NOT broadcast
+- Error path: failed install does NOT broadcast
+
+**Verification:**
+- Package mutations produce `data_changed` WebSocket messages
+- Read-only package operations do NOT produce broadcasts
+
+## System-Wide Impact
+
+- **Interaction graph:** The UI WebSocket handler in `ui/src/lib/ws.ts` listens for messages. Once these broadcasts are added, the server-side infrastructure for real-time updates is in place. Actual UI refetching depends on the UI listener handling new entity types (see issue #32).
+- **Error propagation:** Broadcasts fire after successful mutations only. If the broadcast itself fails (WebSocket disconnected), it fails silently — no impact on the HTTP response.
+- **Unchanged invariants:** Approvals route is not modified. All existing GET/list endpoints are not affected.
+
+## Risks & Dependencies
+
+| Risk | Mitigation |
+|------|------------|
+| PR #49 entity union extension overlaps | Unit 1 checks before modifying; if already extended, it's a no-op |
+| Broadcast fires before response is sent | Place broadcast call after `res.json()` / `res.status().send()` to ensure the client gets the HTTP response regardless |
+
+## Sources & References
+
+- Related issue: i75Corridor/zerohand#34
+- Related issue: i75Corridor/zerohand#32 (UI data_changed listener)
+- Related PR: i75Corridor/zerohand#49 (agent tools — extends WsDataChanged)
+- Pattern: `server/src/routes/approvals.ts` (existing WsManager usage)

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -278,7 +278,7 @@ export interface WsIncomingGlobalChat {
 
 export interface WsDataChanged {
   type: "data_changed";
-  entity: "pipeline" | "step" | "skill";
+  entity: "pipeline" | "step" | "skill" | "trigger" | "approval" | "budget" | "package" | "setting";
   action: "created" | "updated" | "deleted";
   id: string;
 }

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -134,18 +134,15 @@ async function main() {
   app.use(cors());
   app.use(express.json());
 
-  // Routes (approvals needs ws for re-queuing after approve/reject)
+  // Routes
   app.use("/api", createHealthRouter());
   app.use("/api", createPipelinesRouter(db));
   app.use("/api", createPipelineRunsRouter(db));
-  app.use("/api", createTriggersRouter(db));
-  app.use("/api", createBudgetsRouter(db));
   app.use("/api", createStatsRouter(db));
   let globalAgentRef: import("./services/global-agent.js").GlobalAgentService | null = null;
   app.use("/api", createSettingsRouter(db, () => { void globalAgentRef?.resetSession(); }));
   app.use("/api", createFilesRouter());
   app.use("/api", createSkillsRouter());
-  app.use("/api", createPackagesRouter(db));
   app.use("/api", createModelsRouter());
   app.use("/api", createLogsRouter());
 
@@ -161,8 +158,11 @@ async function main() {
   const httpServer = createServer(app);
   const ws = new WsManager(httpServer);
 
-  // Approvals router needs ws for re-queuing runs after approve/reject
+  // Routes that need ws for real-time broadcasts
   app.use("/api", createApprovalsRouter(db, ws));
+  app.use("/api", createTriggersRouter(db, ws));
+  app.use("/api", createBudgetsRouter(db, ws));
+  app.use("/api", createPackagesRouter(db, ws));
 
   const engine = new ExecutionEngine(db, ws);
   const triggers = new TriggerManager(db, ws);

--- a/server/src/routes/budgets.ts
+++ b/server/src/routes/budgets.ts
@@ -3,6 +3,7 @@ import { and, eq } from "drizzle-orm";
 import type { Db } from "@zerohand/db";
 import { budgetPolicies } from "@zerohand/db";
 import type { ApiBudgetPolicy } from "@zerohand/shared";
+import type { WsManager } from "../ws/index.js";
 
 function toApi(row: typeof budgetPolicies.$inferSelect): ApiBudgetPolicy {
   return {
@@ -17,7 +18,7 @@ function toApi(row: typeof budgetPolicies.$inferSelect): ApiBudgetPolicy {
   };
 }
 
-export function createBudgetsRouter(db: Db): Router {
+export function createBudgetsRouter(db: Db, ws: WsManager): Router {
   const router = Router();
 
   router.get("/budgets", async (req, res, next) => {
@@ -47,6 +48,7 @@ export function createBudgetsRouter(db: Db): Router {
         })
         .returning();
       res.status(201).json(toApi(row));
+      ws.broadcast({ type: "data_changed", entity: "budget", action: "created", id: row.id });
     } catch (err) {
       next(err);
     }
@@ -62,6 +64,7 @@ export function createBudgetsRouter(db: Db): Router {
         .returning();
       if (!row) return res.status(404).json({ error: "Budget policy not found" });
       res.json(toApi(row));
+      ws.broadcast({ type: "data_changed", entity: "budget", action: "updated", id: row.id });
     } catch (err) {
       next(err);
     }
@@ -75,6 +78,7 @@ export function createBudgetsRouter(db: Db): Router {
         .returning();
       if (deleted.length === 0) return res.status(404).json({ error: "Budget policy not found" });
       res.status(204).send();
+      ws.broadcast({ type: "data_changed", entity: "budget", action: "deleted", id: req.params.id });
     } catch (err) {
       next(err);
     }

--- a/server/src/routes/packages.ts
+++ b/server/src/routes/packages.ts
@@ -6,6 +6,7 @@ import { spawnSync } from "node:child_process";
 import { desc, eq } from "drizzle-orm";
 import type { Db } from "@zerohand/db";
 import { installedPackages, packageSecurityChecks, pipelines } from "@zerohand/db";
+import type { WsManager } from "../ws/index.js";
 import {
   installPackage,
   updatePackage,
@@ -97,7 +98,7 @@ async function buildPackageDir(
   return { name: pipeline.name, slugName };
 }
 
-export function createPackagesRouter(db: Db): Router {
+export function createPackagesRouter(db: Db, ws: WsManager): Router {
   const router = Router();
 
   // GET /api/packages — list installed packages
@@ -162,6 +163,7 @@ export function createPackagesRouter(db: Db): Router {
       }
       const result = await installPackage(db, repoUrl, getPackagesDir(), getSkillsDir(), { force: force === true });
       res.status(201).json(result);
+      ws.broadcast({ type: "data_changed", entity: "package", action: "created", id: repoUrl });
     } catch (err) {
       next(err);
     }
@@ -208,6 +210,7 @@ export function createPackagesRouter(db: Db): Router {
       const { force } = req.body as { force?: boolean };
       const result = await updatePackage(db, req.params.id, getSkillsDir(), { force: force === true });
       res.json(result);
+      ws.broadcast({ type: "data_changed", entity: "package", action: "updated", id: req.params.id });
     } catch (err) {
       next(err);
     }
@@ -245,6 +248,7 @@ export function createPackagesRouter(db: Db): Router {
     try {
       await uninstallPackage(db, req.params.id, getSkillsDir());
       res.status(204).end();
+      ws.broadcast({ type: "data_changed", entity: "package", action: "deleted", id: req.params.id });
     } catch (err) {
       next(err);
     }
@@ -328,6 +332,7 @@ export function createPackagesRouter(db: Db): Router {
         metadata: pkg.metadata,
         installedAt: pkg.installedAt?.toISOString() ?? null,
       });
+      ws.broadcast({ type: "data_changed", entity: "package", action: "created", id: pkg.id });
     } catch (err) {
       next(err);
     }
@@ -450,6 +455,7 @@ export function createPackagesRouter(db: Db): Router {
         repoFullName: pkg.repoFullName,
         metadata: pkg.metadata,
       });
+      ws.broadcast({ type: "data_changed", entity: "package", action: "created", id: pkg.id });
     } catch (err) {
       next(err);
     } finally {

--- a/server/src/routes/triggers.ts
+++ b/server/src/routes/triggers.ts
@@ -4,6 +4,7 @@ import type { Db } from "@zerohand/db";
 import { triggers } from "@zerohand/db";
 import type { ApiTrigger } from "@zerohand/shared";
 import { computeNextRun } from "../services/trigger-manager.js";
+import type { WsManager } from "../ws/index.js";
 
 function toApi(row: typeof triggers.$inferSelect): ApiTrigger {
   return {
@@ -22,7 +23,7 @@ function toApi(row: typeof triggers.$inferSelect): ApiTrigger {
   };
 }
 
-export function createTriggersRouter(db: Db): Router {
+export function createTriggersRouter(db: Db, ws: WsManager): Router {
   const router = Router();
 
   router.get("/pipelines/:pipelineId/triggers", async (req, res, next) => {
@@ -61,6 +62,7 @@ export function createTriggersRouter(db: Db): Router {
           })
           .returning();
         res.status(201).json(toApi(row));
+        ws.broadcast({ type: "data_changed", entity: "trigger", action: "created", id: row.id });
         return;
       }
 
@@ -78,6 +80,7 @@ export function createTriggersRouter(db: Db): Router {
         })
         .returning();
       res.status(201).json(toApi(row));
+      ws.broadcast({ type: "data_changed", entity: "trigger", action: "created", id: row.id });
     } catch (err) {
       next(err);
     }
@@ -97,6 +100,7 @@ export function createTriggersRouter(db: Db): Router {
         .returning();
       if (!row) return res.status(404).json({ error: "Trigger not found" });
       res.json(toApi(row));
+      ws.broadcast({ type: "data_changed", entity: "trigger", action: "updated", id: row.id });
     } catch (err) {
       next(err);
     }
@@ -110,6 +114,7 @@ export function createTriggersRouter(db: Db): Router {
         .returning();
       if (deleted.length === 0) return res.status(404).json({ error: "Trigger not found" });
       res.status(204).send();
+      ws.broadcast({ type: "data_changed", entity: "trigger", action: "deleted", id: req.params.id });
     } catch (err) {
       next(err);
     }


### PR DESCRIPTION
## Summary

Closes #34

- Pass `WsManager` to `createBudgetsRouter`, `createPackagesRouter`, and `createTriggersRouter`
- Broadcast `data_changed` on every CREATE/UPDATE/DELETE mutation across all three routes
- Extended `WsDataChanged` entity union with `trigger`, `budget`, `package`, `approval`, `setting`
- Moved route registrations after `WsManager` creation in `server/src/index.ts` (they were previously registered before `ws` existed)

### Broadcasts added

| Route | Mutations | Entity |
|-------|-----------|--------|
| Triggers | POST (create cron + channel), PATCH (update), DELETE | `trigger` |
| Budgets | POST (create), PATCH (update), DELETE | `budget` |
| Packages | POST install, POST update, DELETE, POST install-local, POST publish | `package` |

Read-only operations (GET, scan, discover, export, check-updates) do NOT broadcast.

## Test plan
- [x] TypeScript compiles across all packages
- [x] Pre-push hooks pass (build + test + typecheck)
- [ ] Manual test: create a trigger, observe `data_changed` in browser WebSocket console
- [ ] Manual test: delete a budget, observe broadcast
- [ ] Manual test: install a package, observe broadcast

## Post-Deploy Monitoring & Validation
- Monitor server logs for errors in route handlers after broadcast calls
- Check browser WebSocket dev tools for `data_changed` messages with new entity types
- Note: UI refetching depends on issue #32 (UI data_changed listener) — this PR provides the server-side infrastructure
- Validation window: first 24h, spot-check each entity type