### PR TITLE
Add suggested prompt cards to GlobalChatPanel empty state

### DIFF
--- a/docs/plans/2026-04-04-003-feat-chat-suggested-prompts-plan.md
+++ b/docs/plans/2026-04-04-003-feat-chat-suggested-prompts-plan.md
@@ -1,0 +1,77 @@
+---
+title: "feat: Add suggested prompts to GlobalChatPanel empty state"
+type: feat
+status: completed
+date: 2026-04-04
+---
+
+# feat: Add suggested prompts to GlobalChatPanel empty state
+
+## Overview
+
+Replace the static hint text in the chat panel's empty state with 4-6 clickable prompt cards. Clicking a card sends it as a message immediately. Cards disappear after the first message.
+
+## Problem Frame
+
+Users landing on the chat panel see a passive hint ("Ask me about pipelines, runs, skills, or tell me to trigger a run.") with no actionable examples they can click. This scored Capability Discovery at 71% in the agent-native audit.
+
+## Requirements Trace
+
+- R1. Show 4-6 clickable suggested prompt cards when `messages.length === 0`
+- R2. Clicking a card sends the prompt as a user message (same as typing + Enter)
+- R3. Cards disappear after the first message is sent
+- R4. Cards match the existing dark UI theme (slate/sky color palette)
+
+## Scope Boundaries
+
+- Single file change: `ui/src/components/GlobalChatPanel.tsx`
+- No context-aware prompts (stretch goal deferred)
+- No backend changes
+- No new dependencies
+
+## Key Technical Decisions
+
+- **Inline in GlobalChatPanel, not a separate component**: The empty state is a simple conditional block (lines 132-137). The prompt cards replace it directly — no need for a separate file for 20 lines of JSX.
+- **Reuse existing `sendMessage` flow**: Set `input` to the prompt text, then call `sendMessage()` — or more directly, replicate the send logic inline to avoid a flash of the input field being populated.
+- **Direct send on click**: Rather than setting the input and simulating Enter, directly call `wsSend` with the prompt text (same as `sendMessage` does) and add the user message to state. This avoids UI flicker.
+
+## Implementation Units
+
+- [ ] **Unit 1: Replace empty state with clickable prompt cards**
+
+**Goal:** Show suggested prompts when chat is empty; clicking one sends it as a message.
+
+**Requirements:** R1, R2, R3, R4
+
+**Dependencies:** None
+
+**Files:**
+- Modify: `ui/src/components/GlobalChatPanel.tsx`
+
+**Approach:**
+- Define a `SUGGESTED_PROMPTS` array of 5 prompt strings at the top of the component or as a module-level const
+- Replace the empty-state block (lines 132-137) with a grid/flex layout of clickable cards
+- Each card: styled as a small rounded button with slate-800 bg, slate-300 text, hover state (sky-500 border or bg tint)
+- On click: add the prompt as a user message to `messages`, call `wsSend` with the prompt and current context, set `isStreaming` to true — mirrors what `sendMessage()` does but with a hardcoded text instead of `input`
+- The existing condition `messages.length === 0 && !streamingText && !isStreaming` already gates the empty state — once a message is added, cards disappear automatically
+
+**Patterns to follow:**
+- Existing empty state styles in `GlobalChatPanel.tsx` (slate-600 text, centered)
+- Existing button styles in the component (rounded-xl, slate-800/60 bg, border patterns)
+- `sendMessage()` function for the exact send logic
+
+**Test scenarios:**
+- Happy path: panel loads with no messages -> 5 prompt cards visible
+- Happy path: clicking "List all pipelines" card -> card text appears as user message, agent starts streaming
+- Happy path: after first message sent -> cards no longer visible
+- Edge case: rapid-clicking two cards -> only first fires (isStreaming blocks second)
+
+**Verification:**
+- Chat panel shows clickable prompt cards when empty
+- Clicking a card sends it as a message and cards disappear
+- Cards match the dark theme aesthetically
+
+## Sources & References
+
+- Related issue: i75Corridor/zerohand#35
+- Target file: `ui/src/components/GlobalChatPanel.tsx`

--- a/ui/src/components/GlobalChatPanel.tsx
+++ b/ui/src/components/GlobalChatPanel.tsx
@@ -130,10 +130,30 @@ export default function GlobalChatPanel({ onClose }: GlobalChatPanelProps) {
       {/* Messages */}
       <div className="flex-1 overflow-y-auto px-4 py-3 space-y-3 min-h-0">
         {messages.length === 0 && !streamingText && !isStreaming && (
-          <div className="flex items-center justify-center h-full">
-            <p className="text-slate-600 text-sm text-center px-4">
-              Ask me about pipelines, runs, skills, or tell me to trigger a run.
-            </p>
+          <div className="flex flex-col items-center justify-center h-full gap-4 px-2">
+            <p className="text-slate-600 text-sm text-center">What can I help you with?</p>
+            <div className="flex flex-wrap justify-center gap-2 max-w-sm">
+              {[
+                "List all pipelines",
+                "Create a new skill for web scraping",
+                "Show me recent run failures",
+                "What packages are installed?",
+                "Trigger the Daily Absurdist pipeline",
+              ].map((prompt) => (
+                <button
+                  key={prompt}
+                  onClick={() => {
+                    setMessages((m) => [...m, { role: "user", content: prompt, timestamp: new Date() }]);
+                    wsSend({ type: "global_chat", action: "prompt", message: prompt, context: getContext(location.pathname) });
+                    setIsStreaming(true);
+                    setStreamingText("");
+                  }}
+                  className="px-3 py-1.5 text-xs text-slate-300 bg-slate-800/60 border border-slate-700/50 rounded-lg hover:border-sky-500/40 hover:text-white hover:bg-slate-800 transition-colors"
+                >
+                  {prompt}
+                </button>
+              ))}
+            </div>
           </div>
         )}
 


### PR DESCRIPTION
## Summary

Closes #35

Replaces the static hint text in the chat panel's empty state with 5 clickable prompt cards. Clicking a card sends it as a message immediately. Cards disappear after the first message.

### Prompts shown
- "List all pipelines"
- "Create a new skill for web scraping"
- "Show me recent run failures"
- "What packages are installed?"
- "Trigger the Daily Absurdist pipeline"

## Test plan
- [x] TypeScript compiles
- [x] Pre-push hooks pass (build + typecheck)
- [ ] Manual: open chat panel when empty -> 5 prompt cards visible
- [ ] Manual: click a card -> sends as message, cards disappear, agent responds

## Post-Deploy Monitoring & Validation
No additional operational monitoring required — pure UI change with no server-side impact.