### PR TITLE
Add CLI commands for triggers, approvals, budgets, and settings

### DIFF
--- a/docs/plans/2026-04-04-004-feat-cli-entity-commands-plan.md
+++ b/docs/plans/2026-04-04-004-feat-cli-entity-commands-plan.md
@@ -1,0 +1,77 @@
+---
+title: "feat: Add CLI commands for triggers, approvals, budgets, and settings"
+type: feat
+status: completed
+date: 2026-04-04
+---
+
+# feat: Add CLI commands for triggers, approvals, budgets, and settings
+
+## Overview
+
+Add 13 new CLI commands across 4 entity groups (triggers, approvals, budgets, settings) to close the CLI action parity gap. Commands use existing REST API via the CLI's `ApiClient`.
+
+## Requirements Trace
+
+- R1. Triggers: `list [--pipeline]`, `create <pipeline-id> --cron`, `toggle <id>`, `delete <id>`
+- R2. Approvals: `list [--status]`, `approve <id> [--note]`, `reject <id> [--note]`
+- R3. Budgets: `list`, `create --scope --limit`, `delete <id>`
+- R4. Settings: `list`, `set <key> <value>`
+- R5. All commands use existing REST API via `packages/cli/src/api-client.ts`
+- R6. Commands registered in `packages/cli/src/index.ts`
+
+## Scope Boundaries
+
+- No new API routes — all endpoints already exist
+- CLI output uses `formatTable` / `relativeTime` from existing `formatters.ts`
+- No interactive prompts — all params via flags/args
+
+## Key Technical Decisions
+
+- **Extend CLI ApiClient, not MCP ApiClient**: The CLI has its own `ApiClient` in `packages/cli/src/api-client.ts` (separate from the MCP one). Add methods here.
+- **One file per entity group**: Matches `commands/pipelines.ts`, `commands/packages.ts` pattern.
+- **Commander subcommand pattern**: Each group registers via `registerXCommand(program, client)`.
+
+## Implementation Units
+
+- [ ] **Unit 1: Extend CLI ApiClient with trigger/approval/budget/settings methods**
+
+**Files:** Modify: `packages/cli/src/api-client.ts`
+
+**Approach:** Add typed methods matching REST routes for all 4 groups. Import `ApiTrigger`, `ApiApproval`, `ApiBudgetPolicy`, `ApiSetting` from `@zerohand/shared`.
+
+- [ ] **Unit 2: Triggers commands**
+
+**Files:** Create: `packages/cli/src/commands/triggers.ts`
+
+**Approach:** `triggers list [--pipeline <id>]`, `triggers create <pipeline-id> --cron <expr> [--timezone] [--input key=value]`, `triggers toggle <id>` (PATCH enabled=!current), `triggers delete <id>`. Use `formatTable` for list output.
+
+- [ ] **Unit 3: Approvals commands**
+
+**Files:** Create: `packages/cli/src/commands/approvals.ts`
+
+**Approach:** `approvals list [--status pending|approved|rejected]`, `approvals approve <id> [--note]`, `approvals reject <id> [--note]`. Default status filter: pending.
+
+- [ ] **Unit 4: Budgets commands**
+
+**Files:** Create: `packages/cli/src/commands/budgets.ts`
+
+**Approach:** `budgets list`, `budgets create --scope <type:id> --limit <cents>`, `budgets delete <id>`. Parse scope as `type:id` (e.g., `pipeline:abc123`).
+
+- [ ] **Unit 5: Settings commands**
+
+**Files:** Create: `packages/cli/src/commands/settings.ts`
+
+**Approach:** `settings list`, `settings set <key> <value>`. Try JSON.parse on value, fall back to string.
+
+- [ ] **Unit 6: Register all commands in index.ts**
+
+**Files:** Modify: `packages/cli/src/index.ts`
+
+**Approach:** Import and call `registerTriggersCommand`, `registerApprovalsCommand`, `registerBudgetsCommand`, `registerSettingsCommand`. Update description text.
+
+## Sources & References
+
+- Related issue: i75Corridor/zerohand#36
+- Pattern: `packages/cli/src/commands/pipelines.ts`
+- Pattern: `packages/cli/src/commands/packages.ts`

--- a/packages/cli/src/api-client.ts
+++ b/packages/cli/src/api-client.ts
@@ -1,12 +1,16 @@
 import type {
+  ApiApproval,
+  ApiBudgetPolicy,
   ApiDiscoveredPackage,
   ApiInstalledPackage,
   ApiPipeline,
   ApiPipelineRun,
   ApiPipelineStep,
   ApiSecurityReport,
+  ApiSetting,
   ApiSkillBundle,
   ApiStepRun,
+  ApiTrigger,
 } from "@zerohand/shared";
 
 export class ApiError extends Error {
@@ -133,6 +137,70 @@ export class ApiClient {
 
   uninstallPackage(id: string): Promise<void> {
     return this.request("DELETE", `/packages/${id}`);
+  }
+
+  // Triggers
+  listTriggers(pipelineId: string): Promise<ApiTrigger[]> {
+    return this.request("GET", `/pipelines/${pipelineId}/triggers`);
+  }
+
+  createTrigger(pipelineId: string, data: object): Promise<ApiTrigger> {
+    return this.request("POST", `/pipelines/${pipelineId}/triggers`, data);
+  }
+
+  updateTrigger(id: string, data: object): Promise<ApiTrigger> {
+    return this.request("PATCH", `/triggers/${id}`, data);
+  }
+
+  deleteTrigger(id: string): Promise<void> {
+    return this.request("DELETE", `/triggers/${id}`);
+  }
+
+  async listAllTriggers(): Promise<(ApiTrigger & { pipelineName?: string })[]> {
+    const pipelines = await this.listPipelines();
+    const nested = await Promise.all(
+      pipelines.map(async (p) => {
+        const triggers = await this.listTriggers(p.id);
+        return triggers.map((t) => ({ ...t, pipelineName: p.name }));
+      }),
+    );
+    return nested.flat();
+  }
+
+  // Approvals
+  listApprovals(status?: string): Promise<ApiApproval[]> {
+    const qs = status ? `?status=${encodeURIComponent(status)}` : "";
+    return this.request("GET", `/approvals${qs}`);
+  }
+
+  approveStep(id: string, note?: string): Promise<ApiApproval> {
+    return this.request("POST", `/approvals/${id}/approve`, { note });
+  }
+
+  rejectStep(id: string, note?: string): Promise<ApiApproval> {
+    return this.request("POST", `/approvals/${id}/reject`, { note });
+  }
+
+  // Budgets
+  listBudgets(): Promise<ApiBudgetPolicy[]> {
+    return this.request("GET", "/budgets");
+  }
+
+  createBudget(data: object): Promise<ApiBudgetPolicy> {
+    return this.request("POST", "/budgets", data);
+  }
+
+  deleteBudget(id: string): Promise<void> {
+    return this.request("DELETE", `/budgets/${id}`);
+  }
+
+  // Settings
+  listSettings(): Promise<ApiSetting[]> {
+    return this.request("GET", "/settings");
+  }
+
+  updateSetting(key: string, value: unknown): Promise<ApiSetting> {
+    return this.request("PUT", `/settings/${encodeURIComponent(key)}`, { value });
   }
 
   // Helpers

--- a/packages/cli/src/commands/approvals.ts
+++ b/packages/cli/src/commands/approvals.ts
@@ -1,0 +1,40 @@
+import { Command } from "commander";
+import { ApiClient } from "../api-client.js";
+import { formatTable, relativeTime } from "../formatters.js";
+
+export function registerApprovalsCommand(program: Command, client: ApiClient): void {
+  const cmd = program.command("approvals").description("manage pipeline approvals");
+
+  cmd
+    .command("list")
+    .description("list approvals")
+    .option("--status <status>", "filter by status", "pending")
+    .action(async (opts: { status: string }) => {
+      const approvals = await client.listApprovals(opts.status);
+      const rows = approvals.map((a) => ({
+        ID: a.id.slice(0, 8),
+        PIPELINE: a.pipelineName ?? "\u2014",
+        STATUS: a.status,
+        CREATED: relativeTime(a.createdAt),
+      }));
+      console.log(formatTable(rows, ["ID", "PIPELINE", "STATUS", "CREATED"]));
+    });
+
+  cmd
+    .command("approve <id>")
+    .description("approve a pending step")
+    .option("--note <text>", "optional decision note")
+    .action(async (id: string, opts: { note?: string }) => {
+      await client.approveStep(id, opts.note);
+      console.log(`Approved ${id}`);
+    });
+
+  cmd
+    .command("reject <id>")
+    .description("reject a pending step")
+    .option("--note <text>", "optional decision note")
+    .action(async (id: string, opts: { note?: string }) => {
+      await client.rejectStep(id, opts.note);
+      console.log(`Rejected ${id}`);
+    });
+}

--- a/packages/cli/src/commands/budgets.ts
+++ b/packages/cli/src/commands/budgets.ts
@@ -1,0 +1,52 @@
+import { Command } from "commander";
+import { ApiClient } from "../api-client.js";
+import { formatTable } from "../formatters.js";
+
+export function registerBudgetsCommand(program: Command, client: ApiClient): void {
+  const cmd = program.command("budgets").description("manage budget policies");
+
+  cmd
+    .command("list")
+    .description("list budget policies")
+    .action(async () => {
+      const budgets = await client.listBudgets();
+      const rows = budgets.map((b) => ({
+        ID: b.id.slice(0, 8),
+        SCOPE: `${b.scopeType}:${b.scopeId}`,
+        LIMIT: `$${(b.amountCents / 100).toFixed(2)}`,
+        WINDOW: b.windowKind,
+        "WARN%": String(b.warnPercent),
+        HARD_STOP: b.hardStopEnabled ? "✓" : "✗",
+      }));
+      console.log(formatTable(rows, ["ID", "SCOPE", "LIMIT", "WINDOW", "WARN%", "HARD_STOP"]));
+    });
+
+  cmd
+    .command("create")
+    .description("create a budget policy")
+    .requiredOption("--scope <type:id>", "scope as scopeType:scopeId")
+    .requiredOption("--limit <cents>", "budget limit in cents")
+    .action(async (opts: { scope: string; limit: string }) => {
+      const colonIdx = opts.scope.indexOf(":");
+      if (colonIdx === -1) {
+        console.error("--scope must be in the format type:id (e.g. worker:abc123)");
+        process.exit(1);
+      }
+      const scopeType = opts.scope.slice(0, colonIdx);
+      const scopeId = opts.scope.slice(colonIdx + 1);
+      const budget = await client.createBudget({
+        scopeType,
+        scopeId,
+        amountCents: parseInt(opts.limit, 10),
+      });
+      console.log(`Created budget ${budget.id}`);
+    });
+
+  cmd
+    .command("delete <id>")
+    .description("delete a budget policy")
+    .action(async (id: string) => {
+      await client.deleteBudget(id);
+      console.log(`Deleted budget ${id}`);
+    });
+}

--- a/packages/cli/src/commands/settings.ts
+++ b/packages/cli/src/commands/settings.ts
@@ -1,0 +1,34 @@
+import { Command } from "commander";
+import { ApiClient } from "../api-client.js";
+import { formatTable, relativeTime } from "../formatters.js";
+
+export function registerSettingsCommand(program: Command, client: ApiClient): void {
+  const cmd = program.command("settings").description("manage application settings");
+
+  cmd
+    .command("list")
+    .description("list settings")
+    .action(async () => {
+      const settings = await client.listSettings();
+      const rows = settings.map((s) => ({
+        KEY: s.key,
+        VALUE: typeof s.value === "object" ? JSON.stringify(s.value) : String(s.value),
+        UPDATED: relativeTime(s.updatedAt),
+      }));
+      console.log(formatTable(rows, ["KEY", "VALUE", "UPDATED"]));
+    });
+
+  cmd
+    .command("set <key> <value>")
+    .description("set a configuration value")
+    .action(async (key: string, value: string) => {
+      let parsedValue: unknown;
+      try {
+        parsedValue = JSON.parse(value);
+      } catch {
+        parsedValue = value;
+      }
+      await client.updateSetting(key, parsedValue);
+      console.log(`Set ${key} = ${JSON.stringify(parsedValue)}`);
+    });
+}

--- a/packages/cli/src/commands/triggers.ts
+++ b/packages/cli/src/commands/triggers.ts
@@ -1,0 +1,97 @@
+import { Command } from "commander";
+import { ApiClient } from "../api-client.js";
+import { formatTable, relativeTime } from "../formatters.js";
+
+export function registerTriggersCommand(program: Command, client: ApiClient): void {
+  const cmd = program.command("triggers").description("manage pipeline triggers");
+
+  cmd
+    .command("list")
+    .description("list triggers")
+    .option("--pipeline <id>", "filter by pipeline id")
+    .action(async (opts: { pipeline?: string }) => {
+      try {
+        const triggers = opts.pipeline
+          ? (await client.listTriggers(opts.pipeline)).map((t) => ({ ...t, pipelineName: undefined }))
+          : await client.listAllTriggers();
+        const rows = triggers.map((t) => ({
+          ID: t.id.slice(0, 8),
+          PIPELINE: (t as { pipelineName?: string }).pipelineName ?? t.pipelineId.slice(0, 8),
+          TYPE: t.type,
+          CRON: t.cronExpression ?? "",
+          ENABLED: t.enabled ? "✓" : "✗",
+          NEXT_RUN: t.nextRunAt ? relativeTime(t.nextRunAt) : "",
+          CREATED: relativeTime(t.createdAt),
+        }));
+        console.log(formatTable(rows, ["ID", "PIPELINE", "TYPE", "CRON", "ENABLED", "NEXT_RUN", "CREATED"]));
+      } catch (err) {
+        console.error(String(err));
+        process.exit(1);
+      }
+    });
+
+  cmd
+    .command("create <pipeline-id>")
+    .description("create a cron trigger for a pipeline")
+    .requiredOption("--cron <expr>", "cron expression")
+    .option("--timezone <tz>", "timezone (default: UTC)")
+    .option("--input <key=value...>", "default input parameters", (val: string, prev: string[]) => {
+      prev.push(val);
+      return prev;
+    }, [] as string[])
+    .action(async (pipelineId: string, opts: { cron: string; timezone?: string; input: string[] }) => {
+      try {
+        const defaultInputs: Record<string, string> = {};
+        for (const pair of opts.input) {
+          const idx = pair.indexOf("=");
+          if (idx === -1) {
+            console.error(`Invalid input format: ${pair} (expected key=value)`);
+            process.exit(1);
+          }
+          defaultInputs[pair.slice(0, idx)] = pair.slice(idx + 1);
+        }
+        const trigger = await client.createTrigger(pipelineId, {
+          type: "cron",
+          cronExpression: opts.cron,
+          timezone: opts.timezone,
+          defaultInputs,
+        });
+        console.log(`Created trigger ${trigger.id} for pipeline ${pipelineId}`);
+      } catch (err) {
+        console.error(String(err));
+        process.exit(1);
+      }
+    });
+
+  cmd
+    .command("toggle <id>")
+    .description("toggle a trigger enabled/disabled")
+    .action(async (id: string) => {
+      try {
+        const all = await client.listAllTriggers();
+        const current = all.find((t) => t.id === id || t.id.startsWith(id));
+        if (!current) {
+          console.error(`Trigger ${id} not found`);
+          process.exit(1);
+        }
+        await client.updateTrigger(current.id, { enabled: !current.enabled });
+        console.log(`Trigger ${current.id.slice(0, 8)} is now ${current.enabled ? "disabled" : "enabled"}`);
+      } catch (err) {
+        console.error(String(err));
+        process.exit(1);
+      }
+    });
+
+  cmd
+    .command("delete <id>")
+    .description("delete a trigger")
+    .action(async (id: string) => {
+      try {
+        await client.deleteTrigger(id);
+        console.log(`Deleted trigger ${id}`);
+      } catch (err) {
+        console.error(String(err));
+        process.exit(1);
+      }
+    });
+}

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -5,12 +5,16 @@ import { registerRunCommand } from "./commands/run.js";
 import { registerRunsCommand } from "./commands/runs.js";
 import { registerPipelinesCommand } from "./commands/pipelines.js";
 import { registerPackagesCommand } from "./commands/packages.js";
+import { registerTriggersCommand } from "./commands/triggers.js";
+import { registerApprovalsCommand } from "./commands/approvals.js";
+import { registerBudgetsCommand } from "./commands/budgets.js";
+import { registerSettingsCommand } from "./commands/settings.js";
 import { registerNewCommand } from "./commands/new.js";
 import { registerConfigCommand } from "./commands/config-cmd.js";
 
 const program = new Command()
   .name("zerohand")
-  .description("Zerohand CLI — manage pipelines, runs, and packages")
+  .description("Zerohand CLI — manage pipelines, runs, packages, triggers, approvals, budgets, and settings")
   .version("0.1.0");
 
 const serverUrl = getServerUrl();
@@ -21,6 +25,10 @@ registerRunCommand(program, client, serverUrl);
 registerRunsCommand(program, client, serverUrl);
 registerPipelinesCommand(program, client);
 registerPackagesCommand(program, client);
+registerTriggersCommand(program, client);
+registerApprovalsCommand(program, client);
+registerBudgetsCommand(program, client);
+registerSettingsCommand(program, client);
 registerNewCommand(program);
 registerConfigCommand(program);
 


### PR DESCRIPTION
## Summary

Closes #36

Adds 13 CLI commands across 4 entity groups to close the CLI action parity gap:

| Group | Commands |
|-------|----------|
| Triggers | `list [--pipeline]`, `create <pipeline-id> --cron`, `toggle <id>`, `delete <id>` |
| Approvals | `list [--status]`, `approve <id> [--note]`, `reject <id> [--note]` |
| Budgets | `list`, `create --scope <type:id> --limit <cents>`, `delete <id>` |
| Settings | `list`, `set <key> <value>` |

All commands use existing REST API via the CLI's ApiClient. Output uses `formatTable` for consistent formatting.

## Test plan
- [x] TypeScript compiles across all packages
- [x] Pre-push hooks pass (build + test + typecheck)
- [ ] Manual: `zerohand triggers list` returns trigger table
- [ ] Manual: `zerohand approvals list --status pending` returns pending approvals
- [ ] Manual: `zerohand settings list` returns settings table
- [ ] Manual: `zerohand budgets create --scope pipeline:abc --limit 1000` creates budget

## Post-Deploy Monitoring & Validation
No additional operational monitoring required — CLI commands use existing REST API with no server-side changes.