### PR TITLE
fix: prevent duplicate WebSocket connections causing doubled Agent AI responses

### DIFF
--- a/ui/src/lib/ws.ts
+++ b/ui/src/lib/ws.ts
@@ -63,7 +63,10 @@ export function useWebSocket(onMessage: WsHandler) {
       if (refCount === 0 && sharedSocket) {
         // Suppress the "closed before connection established" browser warning by
         // replacing onerror with a no-op before closing a still-connecting socket.
+        // Also null out onclose to prevent the auto-reconnect logic from firing
+        // after an intentional close (e.g. React StrictMode cleanup).
         sharedSocket.onerror = () => {};
+        sharedSocket.onclose = null;
         sharedSocket.close();
         sharedSocket = null;
       }


### PR DESCRIPTION
## Summary
- Null out `onclose` before intentionally closing the shared WebSocket in `useWebSocket` cleanup, preventing React StrictMode's mount-cleanup-remount cycle from triggering auto-reconnect on the closed socket and creating an orphaned duplicate connection that doubles all Agent AI text deltas.

Closes #68

## Test plan
- [ ] Open Agent AI panel and send a message — response text should not be doubled
- [ ] Resize browser to mobile width — panel should switch to overlay without duplication
- [ ] Close and reopen the panel — no duplicate connections on reconnect

🤖 Generated with [Claude Code](https://claude.com/claude-code)