### PR TITLE
feat: MCP client OAuth 2.1 support

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,104 @@
+# AGENTS.md
+
+This file provides guidance to AI coding agents when working with code in this repository.
+
+## Commands
+
+```bash
+pnpm dev                        # Start server (3009) + UI (3008) concurrently
+pnpm build                      # Build all: db → server → ui → cli → mcp
+pnpm typecheck                  # TypeScript check all packages
+pnpm test                       # Run vitest across server + cli
+pnpm test:watch                 # Watch mode for server tests
+pnpm --filter server test       # Server tests only
+pnpm db:generate                # Generate Drizzle migration SQL from schema changes
+pnpm db:reset                   # Wipe embedded postgres data (reinits on next dev)
+pnpm reset                      # Full .data directory reset
+```
+
+Pre-push hook (lefthook) runs sequentially: typecheck → test → build. All must pass before push.
+
+## Architecture
+
+Pawn is an agentic workflow orchestrator built on [pi.dev](https://github.com/badlogic/pi-mono). pnpm monorepo with 6 workspaces:
+
+| Package | Scope | Purpose |
+|---------|-------|---------|
+| `packages/db` | `@pawn/db` | Drizzle ORM schema, migrations, postgres client |
+| `packages/shared` | `@pawn/shared` | API types (`Api*` interfaces), status enums, WS message types |
+| `server` | — | Express API, embedded postgres, execution engine, services |
+| `ui` | — | React SPA (Vite, Tailwind, React Query, React Router) |
+| `packages/cli` | `@i75corridor/pawn-cli` | CLI tool: manage pipelines/runs/approvals from terminal |
+| `packages/mcp` | `@i75corridor/pawn-mcp` | MCP server: expose Pawn as tools/resources for AI assistants |
+
+### Server startup (`server/src/index.ts`)
+1. Load `.env` via custom `env-loader.ts`
+2. Initialize OAuth encryption key → `DATA_DIR/oauth-encryption.key`
+3. Start postgres: `DATABASE_URL` env → `database.json` in `.data/` → embedded postgres
+4. Auto-apply migrations from `packages/db/src/migrations/`
+5. Register Express routers on `/api/*`, WebSocket on `/ws`
+6. Init services: ExecutionEngine, TriggerManager, GlobalAgentService, Ollama polling, OAuth refresh polling
+7. Cleanup expired OAuth pending flows
+
+### Execution engine (`server/src/services/execution-engine.ts`)
+Pipeline runs execute steps sequentially. Each step: resolve prompt template (`{{input.key}}`, `{{steps.N.output}}`, `{{secret.VAR}}`) → check approval gate → check budget → execute via Pi.dev agent session (with skill system prompt + tools) → stream events via WebSocket → record cost.
+
+### Dual tool system
+Agent tools exist in two parallel systems that must stay in sync:
+- **In-app tools** (`server/src/services/tools/`): Direct Drizzle ORM access, `ToolDefinition` from pi-ai
+- **MCP tools** (`packages/mcp/src/tools/`): Delegate to HTTP API via `ApiClient`, zod schema records
+
+When adding new tools, infrastructure changes come first (shared types, ApiClient methods, WsDataChanged entity union), then parallel implementation in both systems. See `docs/solutions/best-practices/adding-agent-tools-dual-system-architecture-2026-04-04.md`.
+
+### MCP client (`server/src/services/mcp-client.ts`)
+`McpClientPool` connects to external MCP servers, bridges their tools to the Pi.dev agent. Supports OAuth 2.1 via the SDK's `authProvider` option on HTTP transports. Pool requires `setDb(db)` to enable OAuth token lookup.
+
+### Database
+- **Embedded postgres** (dev): auto-managed in `.data/postgres/`, auto-detected port
+- **External postgres**: `DATABASE_URL` env var or `database.json` in `.data/`
+- Migrations auto-apply on startup via `applyPendingMigrations()`
+
+## Code Conventions
+
+### TypeScript / Imports
+- ESM throughout (`"type": "module"`). **Always use `.js` extensions** in local imports.
+- Target ES2023 (server), ES2020 (UI). Strict mode enabled.
+- Workspace imports: `import { mcpServers } from "@pawn/db"`
+
+### Database (Drizzle ORM)
+- Schema files: `packages/db/src/schema/`, one file per entity, re-exported from `index.ts`
+- UUIDs as PKs: `uuid("id").primaryKey().defaultRandom()`
+- Timestamps: `timestamp("created_at", { withTimezone: true }).notNull().defaultNow()`
+- JSONB columns typed: `jsonb("field").$type<SomeType>()`
+- Text columns for enums (not postgres enums)
+- FKs with cascade: `.references(() => table.id, { onDelete: "cascade" })`
+- Migration workflow: edit schema → `pnpm db:generate` → SQL file created → auto-applied on next startup
+
+### API routes (`server/src/routes/`)
+- Factory functions: `makeFooRouter(db): Router` or `createFooRouter(db): Router`
+- Mounted at `/api` prefix in `server/src/index.ts`
+- Standard REST: GET list, GET `:id`, POST create, PATCH update, DELETE
+- Row → API type mapping via `rowToApi()` helpers
+- All response types prefixed `Api*` in `@pawn/shared`
+- Errors: 400 validation, 404 not found, 409 conflict, 502 upstream failure
+
+### Frontend (`ui/src/`)
+- React Query: `useQuery` with descriptive `queryKey`, `useMutation` with `onSuccess: () => queryClient.invalidateQueries()`
+- API client: `ui/src/lib/api.ts` — typed methods wrapping fetch, `ApiError` class
+- Design tokens: `pawn-gold-*`, `pawn-surface-*` colors; `rounded-card`, `rounded-button` radii; `text-pawn-text-primary`, `text-pawn-text-secondary`
+- Icons: lucide-react
+- WebSocket: `ui/src/lib/ws.ts` with `useDataChangedListener` hook for real-time updates
+- Pages lazy-loaded via React Router
+
+### Config file convention
+New config files follow the `DATA_DIR` + JSON file pattern (see `database.json`, `providers.json`). Env var always overrides file. Fail-fast on malformed security config — never fall through to insecure defaults. Mask secrets at the API boundary before any response leaves the server.
+
+## Key Integration Points
+
+When adding a new field to a database table, **grep every place the entity's config object is constructed** — not just where it's consumed. The compiler won't catch omissions in optional/JSONB fields. See `docs/solutions/best-practices/mcp-oauth-config-propagation-through-all-code-paths-2026-04-12.md`.
+
+When adding UI for a new feature, verify the component's default visibility matches the action's importance. Primary CTAs belong at the top level; supplementary details can live behind expand/collapse.
+
+## Documented Solutions
+
+`docs/solutions/` contains documented solutions to past problems (bugs, best practices, workflow patterns), organized by category with YAML frontmatter (`module`, `tags`, `problem_type`). Search here before implementing features or debugging in documented areas.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,104 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Commands
+
+```bash
+pnpm dev                        # Start server (3009) + UI (3008) concurrently
+pnpm build                      # Build all: db → server → ui → cli → mcp
+pnpm typecheck                  # TypeScript check all packages
+pnpm test                       # Run vitest across server + cli
+pnpm test:watch                 # Watch mode for server tests
+pnpm --filter server test       # Server tests only
+pnpm db:generate                # Generate Drizzle migration SQL from schema changes
+pnpm db:reset                   # Wipe embedded postgres data (reinits on next dev)
+pnpm reset                      # Full .data directory reset
+```
+
+Pre-push hook (lefthook) runs sequentially: typecheck → test → build. All must pass before push.
+
+## Architecture
+
+Pawn is an agentic workflow orchestrator built on [pi.dev](https://github.com/badlogic/pi-mono). pnpm monorepo with 6 workspaces:
+
+| Package | Scope | Purpose |
+|---------|-------|---------|
+| `packages/db` | `@pawn/db` | Drizzle ORM schema, migrations, postgres client |
+| `packages/shared` | `@pawn/shared` | API types (`Api*` interfaces), status enums, WS message types |
+| `server` | — | Express API, embedded postgres, execution engine, services |
+| `ui` | — | React SPA (Vite, Tailwind, React Query, React Router) |
+| `packages/cli` | `@i75corridor/pawn-cli` | CLI tool: manage pipelines/runs/approvals from terminal |
+| `packages/mcp` | `@i75corridor/pawn-mcp` | MCP server: expose Pawn as tools/resources for AI assistants |
+
+### Server startup (`server/src/index.ts`)
+1. Load `.env` via custom `env-loader.ts`
+2. Initialize OAuth encryption key → `DATA_DIR/oauth-encryption.key`
+3. Start postgres: `DATABASE_URL` env → `database.json` in `.data/` → embedded postgres
+4. Auto-apply migrations from `packages/db/src/migrations/`
+5. Register Express routers on `/api/*`, WebSocket on `/ws`
+6. Init services: ExecutionEngine, TriggerManager, GlobalAgentService, Ollama polling, OAuth refresh polling
+7. Cleanup expired OAuth pending flows
+
+### Execution engine (`server/src/services/execution-engine.ts`)
+Pipeline runs execute steps sequentially. Each step: resolve prompt template (`{{input.key}}`, `{{steps.N.output}}`, `{{secret.VAR}}`) → check approval gate → check budget → execute via Pi.dev agent session (with skill system prompt + tools) → stream events via WebSocket → record cost.
+
+### Dual tool system
+Agent tools exist in two parallel systems that must stay in sync:
+- **In-app tools** (`server/src/services/tools/`): Direct Drizzle ORM access, `ToolDefinition` from pi-ai
+- **MCP tools** (`packages/mcp/src/tools/`): Delegate to HTTP API via `ApiClient`, zod schema records
+
+When adding new tools, infrastructure changes come first (shared types, ApiClient methods, WsDataChanged entity union), then parallel implementation in both systems. See `docs/solutions/best-practices/adding-agent-tools-dual-system-architecture-2026-04-04.md`.
+
+### MCP client (`server/src/services/mcp-client.ts`)
+`McpClientPool` connects to external MCP servers, bridges their tools to the Pi.dev agent. Supports OAuth 2.1 via the SDK's `authProvider` option on HTTP transports. Pool requires `setDb(db)` to enable OAuth token lookup.
+
+### Database
+- **Embedded postgres** (dev): auto-managed in `.data/postgres/`, auto-detected port
+- **External postgres**: `DATABASE_URL` env var or `database.json` in `.data/`
+- Migrations auto-apply on startup via `applyPendingMigrations()`
+
+## Code Conventions
+
+### TypeScript / Imports
+- ESM throughout (`"type": "module"`). **Always use `.js` extensions** in local imports.
+- Target ES2023 (server), ES2020 (UI). Strict mode enabled.
+- Workspace imports: `import { mcpServers } from "@pawn/db"`
+
+### Database (Drizzle ORM)
+- Schema files: `packages/db/src/schema/`, one file per entity, re-exported from `index.ts`
+- UUIDs as PKs: `uuid("id").primaryKey().defaultRandom()`
+- Timestamps: `timestamp("created_at", { withTimezone: true }).notNull().defaultNow()`
+- JSONB columns typed: `jsonb("field").$type<SomeType>()`
+- Text columns for enums (not postgres enums)
+- FKs with cascade: `.references(() => table.id, { onDelete: "cascade" })`
+- Migration workflow: edit schema → `pnpm db:generate` → SQL file created → auto-applied on next startup
+
+### API routes (`server/src/routes/`)
+- Factory functions: `makeFooRouter(db): Router` or `createFooRouter(db): Router`
+- Mounted at `/api` prefix in `server/src/index.ts`
+- Standard REST: GET list, GET `:id`, POST create, PATCH update, DELETE
+- Row → API type mapping via `rowToApi()` helpers
+- All response types prefixed `Api*` in `@pawn/shared`
+- Errors: 400 validation, 404 not found, 409 conflict, 502 upstream failure
+
+### Frontend (`ui/src/`)
+- React Query: `useQuery` with descriptive `queryKey`, `useMutation` with `onSuccess: () => queryClient.invalidateQueries()`
+- API client: `ui/src/lib/api.ts` — typed methods wrapping fetch, `ApiError` class
+- Design tokens: `pawn-gold-*`, `pawn-surface-*` colors; `rounded-card`, `rounded-button` radii; `text-pawn-text-primary`, `text-pawn-text-secondary`
+- Icons: lucide-react
+- WebSocket: `ui/src/lib/ws.ts` with `useDataChangedListener` hook for real-time updates
+- Pages lazy-loaded via React Router
+
+### Config file convention
+New config files follow the `DATA_DIR` + JSON file pattern (see `database.json`, `providers.json`). Env var always overrides file. Fail-fast on malformed security config — never fall through to insecure defaults. Mask secrets at the API boundary before any response leaves the server.
+
+## Key Integration Points
+
+When adding a new field to a database table, **grep every place the entity's config object is constructed** — not just where it's consumed. The compiler won't catch omissions in optional/JSONB fields. See `docs/solutions/best-practices/mcp-oauth-config-propagation-through-all-code-paths-2026-04-12.md`.
+
+When adding UI for a new feature, verify the component's default visibility matches the action's importance. Primary CTAs belong at the top level; supplementary details can live behind expand/collapse.
+
+## Documented Solutions
+
+`docs/solutions/` contains documented solutions to past problems (bugs, best practices, workflow patterns), organized by category with YAML frontmatter (`module`, `tags`, `problem_type`). Search here before implementing features or debugging in documented areas.

--- a/docs/plans/2026-04-08-001-feat-mcp-oauth-client-support-plan.md
+++ b/docs/plans/2026-04-08-001-feat-mcp-oauth-client-support-plan.md
@@ -1,7 +1,7 @@
 ---
 title: "feat: Add MCP Client OAuth 2.1 Support"
 type: feat
-status: active
+status: completed
 date: 2026-04-08
 ---
 

--- a/docs/plans/2026-04-08-001-feat-mcp-oauth-client-support-plan.md
+++ b/docs/plans/2026-04-08-001-feat-mcp-oauth-client-support-plan.md
@@ -1,0 +1,512 @@
+---
+title: "feat: Add MCP Client OAuth 2.1 Support"
+type: feat
+status: active
+date: 2026-04-08
+---
+
+# feat: Add MCP Client OAuth 2.1 Support
+
+## Overview
+
+Add first-class OAuth 2.1 authorization support for HTTP-based MCP servers, compliant with the MCP Authorization specification. Leverage the MCP SDK's built-in OAuth client (`@modelcontextprotocol/sdk/client/auth.js`) for discovery, PKCE, and token exchange — implementing the SDK's `OAuthClientProvider` interface with database-backed encrypted token storage. When a user connects an MCP server that requires authentication, Pawn handles the full lifecycle: discovery, authorization, token exchange, encrypted storage, automatic refresh, and Bearer token injection.
+
+## Problem Frame
+
+MCP servers requiring OAuth authentication cannot be used without manually obtaining tokens out-of-band, storing them as static headers, and manually refreshing when they expire. This is friction-heavy compared to modern data connector experiences. The MCP spec defines a standard authorization flow based on OAuth 2.1, and Pawn should implement it as a first-class client.
+
+## Requirements Trace
+
+- R1. Support the MCP Authorization spec flow: 401 → Protected Resource Metadata discovery → Auth Server discovery → OAuth 2.1 authorization code flow with PKCE → Bearer token injection
+- R2. Encrypt OAuth tokens (access + refresh) at rest using AES-256-GCM
+- R3. Automatically refresh tokens before expiration via background polling
+- R4. Provide UI for initiating OAuth connections, viewing status, and disconnecting
+- R5. Support user-provided client credentials (client ID/secret per MCP server)
+- R6. System-wide connections (one OAuth connection per MCP server, not per-user)
+- R7. Implement Resource Indicators (RFC 8707) — include `resource` parameter in auth/token requests
+- R8. Support step-up authorization (handle 403 insufficient_scope by re-authorizing with expanded scopes)
+- R9. Support authorization server discovery via both RFC 8414 and OpenID Connect Discovery
+- R10. Handle token revocation and graceful degradation when tokens expire or are revoked
+
+## Scope Boundaries
+
+- OAuth 2.1 only — no OAuth 1.0a support
+- HTTP-based transports only (sse, streamable-http) — stdio uses environment credentials per MCP spec
+- System-wide connections only — per-user scoping deferred
+- No Dynamic Client Registration in initial release — users provide client credentials
+- No SAML/OIDC enterprise SSO
+- No multi-workspace support (e.g., multiple Slack workspaces per server)
+
+## Context & Research
+
+### Relevant Code and Patterns
+
+- `packages/db/src/schema/mcp-servers.ts` — existing MCP server table, Drizzle ORM pattern
+- `server/src/routes/mcp-servers.ts` — Express router with standard CRUD + test/tools endpoints
+- `server/src/services/mcp-client.ts` — `McpClientPool` with `buildTransport()` that constructs HTTP transports with headers; `SSEClientTransport` and `StreamableHTTPClientTransport` already accept an `authProvider` option
+- `@modelcontextprotocol/sdk` v1.29.0 — ships complete OAuth client: `OAuthClientProvider` interface, `auth()` orchestrator, `startAuthorization()`, `exchangeAuthorization()`, `refreshAuthorization()`, `discoverOAuthProtectedResourceMetadata()`, `discoverOAuthServerInfo()`
+- `packages/shared/src/index.ts` — `ApiMcpServer` interface, shared types
+- `ui/src/pages/Settings.tsx` — MCP server management UI with `McpServerRow` component
+- `ui/src/lib/api.ts` — API client with `ApiError` class and standard fetch patterns
+- `packages/db/src/migrations/` — Drizzle Kit SQL migrations (currently at 0016)
+
+### Institutional Learnings
+
+- **Config resolution chain**: Follow `DATA_DIR` + file convention for encryption key (see `database.json`, `providers.json` patterns)
+- **Fail-fast on invalid security config**: If encryption key file exists but is malformed, exit immediately — never fall through to insecure defaults
+- **Mask secrets at API boundary**: Use single masking point before any response leaves the server (see `maskSensitiveSetting()` pattern)
+- **Route handlers own the logic**: MCP tools delegate to HTTP routes, not direct DB access. OAuth flow logic belongs in route handlers/service layer, not reimplemented per consumer
+
+### External References
+
+- MCP Authorization Specification: https://spec.modelcontextprotocol.io/specification/draft/basic/authorization/
+- OAuth 2.1 Draft: https://datatracker.ietf.org/doc/html/draft-ietf-oauth-v2-1-13
+- RFC 9728: OAuth 2.0 Protected Resource Metadata
+- RFC 8414: OAuth 2.0 Authorization Server Metadata
+- RFC 8707: Resource Indicators for OAuth 2.0
+
+## Key Technical Decisions
+
+- **Implement MCP SDK's `OAuthClientProvider` interface**: Rather than building discovery and PKCE from scratch, implement the SDK's `OAuthClientProvider` backed by database storage. The SDK's `auth()` orchestrator and HTTP transports' `authProvider` option handle the protocol flow. Our implementation provides `tokens()`, `saveTokens()`, `clientInformation()`, `saveClientInformation()`, `saveCodeVerifier()`, `codeVerifier()`, and `redirectToAuthorization()`.
+- **Server-mediated redirect flow**: Since the OAuth flow is server-initiated (not browser SPA), `redirectToAuthorization()` returns the authorization URL to the frontend rather than performing a redirect. Two-phase: (a) POST /connect returns the auth URL, (b) GET /callback handles the redirect.
+- **AES-256-GCM for token encryption**: Key auto-generated and persisted to `DATA_DIR/oauth-encryption.key` (following established file-based config convention). `OAUTH_ENCRYPTION_KEY` env var overrides for production.
+- **Polling-based token refresh**: `setInterval` at 60 seconds (following `startOllamaPolling` pattern). The SDK's `refreshAuthorization()` handles the actual refresh protocol.
+- **OAuth state in database**: Pending flow state (PKCE verifier, scopes, metadata) stored in `oauth_pending_flows` table with 10-minute TTL.
+- **Client credentials in `mcp_servers` table**: Extend with `oauth_config` JSONB column.
+
+## Open Questions
+
+### Resolved During Planning
+
+- **OAuth version scope**: OAuth 2.1 per MCP spec — not 1.0a
+- **Connection scoping**: System-wide. Multi-user deferred.
+- **Client credential model**: User-provided. No pre-shipped provider configs.
+- **PKCE**: Required, S256 method (handled by MCP SDK).
+- **Discovery implementation**: Use MCP SDK's `discoverOAuthProtectedResourceMetadata()` and `discoverOAuthServerInfo()` rather than hand-rolling.
+
+### Deferred to Implementation
+
+- **Token encryption key rotation strategy**: Single key for v1. Rotation added later.
+- **Retry behavior for failed token refresh**: Exact backoff tuned during implementation.
+- **Whether to support Client ID Metadata Documents**: MCP spec recommends them but requires hosting an HTTPS endpoint. Pre-registration sufficient for v1.
+- **Exact `OAuthClientProvider.redirectToAuthorization()` implementation**: The SDK expects this to perform a redirect, but our server-mediated flow needs to return the URL. May need to wrap `auth()` or use `startAuthorization()` directly.
+
+## High-Level Technical Design
+
+> *This illustrates the intended approach and is directional guidance for review, not implementation specification. The implementing agent should treat it as context, not code to reproduce.*
+
+```mermaid
+sequenceDiagram
+    participant UI as Settings UI
+    participant API as Pawn API
+    participant DB as Database
+    participant SDK as MCP SDK auth()
+    participant Browser as User Browser
+    participant MCP as MCP Server
+    participant AS as Auth Server
+
+    Note over UI: User clicks "Connect OAuth"
+    UI->>API: POST /api/mcp-servers/:id/oauth/connect
+    API->>SDK: startAuthorization() or auth()
+    SDK->>MCP: GET (unauthenticated) → 401
+    SDK->>MCP: discoverOAuthProtectedResourceMetadata()
+    SDK->>AS: discoverOAuthServerInfo()
+    SDK->>API: OAuthClientProvider.saveCodeVerifier()
+    API->>DB: Store pending flow (state, verifier, metadata)
+    SDK-->>API: { authorizationUrl }
+    API-->>UI: { authUrl, state }
+    UI->>Browser: window.open(authUrl)
+    Browser->>AS: Auth request + PKCE + resource
+    AS-->>Browser: Redirect with code
+    Browser->>API: GET /api/oauth/callback?code=...&state=...
+    API->>SDK: exchangeAuthorization(code)
+    SDK->>AS: POST token endpoint + code_verifier
+    AS-->>SDK: { access_token, refresh_token, expires_in }
+    SDK->>API: OAuthClientProvider.saveTokens()
+    API->>DB: Store encrypted tokens
+    API-->>Browser: Redirect to Settings
+
+    Note over API: On MCP connection
+    API->>DB: Get oauth_connection
+    API->>API: Decrypt token
+    API->>MCP: Request + Authorization: Bearer <token>
+```
+
+## Implementation Units
+
+- [ ] **Unit 1: Token Encryption Service**
+
+**Goal:** Create a reusable encryption service for storing OAuth tokens securely at rest.
+
+**Requirements:** R2
+
+**Dependencies:** None
+
+**Files:**
+- Create: `server/src/services/oauth-crypto.ts`
+- Test: `server/src/services/__tests__/oauth-crypto.test.ts`
+
+**Approach:**
+- AES-256-GCM with random 12-byte IV per encryption
+- Key sourced from `OAUTH_ENCRYPTION_KEY` env var (hex-encoded 32-byte key)
+- If env var not set, auto-generate key and persist to `DATA_DIR/oauth-encryption.key` (following `database.json` pattern)
+- If key file exists but is malformed, fail-fast with clear error (per institutional learning)
+- Export `encrypt(plaintext: string): string` → `iv:ciphertext:authTag` (all base64)
+- Export `decrypt(encrypted: string): string` → plaintext
+- Export `ensureEncryptionKey(): string` for startup initialization — returns the key path for logging
+
+**Patterns to follow:**
+- `server/src/services/channel-manager.ts` for node:crypto usage
+- `server/src/services/database-config.ts` for DATA_DIR file-based config pattern
+
+**Test scenarios:**
+- Happy path: encrypt then decrypt a token string returns the original
+- Happy path: two encryptions of the same plaintext produce different ciphertexts (unique IV)
+- Edge case: empty string encrypts and decrypts correctly
+- Error path: decrypt with wrong key throws
+- Error path: decrypt with corrupted ciphertext throws
+- Error path: decrypt with malformed format (missing IV or auth tag) throws
+
+**Verification:**
+- Can round-trip encrypt/decrypt arbitrary strings
+- Different IVs per call confirmed by test
+
+---
+
+- [ ] **Unit 2: Database Schema — OAuth Tables**
+
+**Goal:** Add database tables for OAuth connections and pending flows, extend mcp_servers with OAuth config.
+
+**Requirements:** R1, R2, R5, R6
+
+**Dependencies:** Unit 1
+
+**Files:**
+- Modify: `packages/db/src/schema/mcp-servers.ts`
+- Create: `packages/db/src/schema/oauth-connections.ts`
+- Modify: `packages/db/src/schema/index.ts`
+- Create: `packages/db/src/migrations/0017_add_oauth_support.sql`
+
+**Approach:**
+- New `oauth_connections` table: id (uuid PK), mcp_server_id (FK → mcp_servers, cascade delete, unique), access_token (text, encrypted), refresh_token (text, nullable, encrypted), expires_at (timestamptz), scope (text), token_type (text, default 'Bearer'), status ('active' | 'expired' | 'revoked' | 'error'), connected_at (timestamptz), last_refreshed_at (timestamptz, nullable), error_message (text, nullable), auth_server_url (text — needed for refresh), client_registration (jsonb, nullable — for SDK `clientInformation()`)
+- New `oauth_pending_flows` table: id (uuid PK), mcp_server_id (FK), state (text, unique), code_verifier (text), redirect_uri (text), scopes (text), resource_uri (text), auth_server_metadata (jsonb), created_at (timestamptz), expires_at (timestamptz, default now+10min)
+- Extend `mcp_servers` with `oauth_config` JSONB column: `{ clientId: string, clientSecret?: string, scopes?: string[] }`
+- Unique constraint on `oauth_connections.mcp_server_id` enforces system-wide (one connection per server)
+
+**Patterns to follow:**
+- `packages/db/src/schema/mcp-servers.ts` for table definition style (uuid PK, timestamptz, JSONB typed)
+- `packages/db/src/migrations/0015_rename_packages_to_blueprints.sql` for migration style
+
+**Test expectation:** none — schema-only change verified by migration application
+
+**Verification:**
+- Migration applies cleanly to existing database
+- Schema exports available from `@pawn/db`
+
+---
+
+- [ ] **Unit 3: Shared Types — OAuth API Types**
+
+**Goal:** Add shared TypeScript interfaces for OAuth-related API payloads.
+
+**Requirements:** R1, R4
+
+**Dependencies:** Unit 2
+
+**Files:**
+- Modify: `packages/shared/src/index.ts`
+
+**Approach:**
+- Add `ApiOAuthConnection` interface: id, mcpServerId, status, scope, tokenType, connectedAt, lastRefreshedAt, expiresAt, errorMessage (no raw tokens exposed to frontend)
+- Add `ApiOAuthConfig` interface: clientId, hasClientSecret (boolean, never expose raw secret), scopes
+- Extend `ApiMcpServer` with optional `oauthConfig?: ApiOAuthConfig` and `oauthConnection?: ApiOAuthConnection`
+- Add `ApiOAuthConnectResponse` interface: authUrl, state
+- Add `ApiOAuthStatus` type union: 'active' | 'expired' | 'revoked' | 'error' | 'disconnected'
+
+**Patterns to follow:**
+- Existing `ApiMcpServer`, `ApiMcpTool` interface patterns in `packages/shared/src/index.ts`
+- Masking pattern: `hasClientSecret: boolean` instead of exposing the value (per institutional learning)
+
+**Test expectation:** none — type definitions only, verified by TypeScript compilation
+
+**Verification:**
+- Types compile without errors
+- Types used by both server and UI packages
+
+---
+
+- [ ] **Unit 4: OAuthClientProvider Implementation (SDK Integration)**
+
+**Goal:** Implement the MCP SDK's `OAuthClientProvider` interface backed by database storage and encryption.
+
+**Requirements:** R1, R2, R5, R7, R9
+
+**Dependencies:** Unit 1, Unit 2
+
+**Files:**
+- Create: `server/src/services/oauth-provider.ts`
+- Test: `server/src/services/__tests__/oauth-provider.test.ts`
+
+**Approach:**
+- Implement `OAuthClientProvider` interface from `@modelcontextprotocol/sdk/client/auth.js`
+- Constructor takes `db: Db`, `mcpServerId: string`, `redirectUri: string`
+- `clientInformation()`: Read from `mcp_servers.oauth_config` (client_id, client_secret)
+- `saveClientInformation()`: Update `oauth_connections.client_registration` JSONB
+- `tokens()`: Read from `oauth_connections`, decrypt tokens, return SDK `OAuthTokens` format
+- `saveTokens()`: Encrypt tokens via oauth-crypto, upsert into `oauth_connections`
+- `codeVerifier()`: Read from `oauth_pending_flows` by server ID
+- `saveCodeVerifier()`: Store in `oauth_pending_flows`
+- `redirectToAuthorization(authorizationUrl)`: Store the URL in a class property (server-mediated flow — we capture the URL rather than redirecting). This is the key adaptation point.
+- Also export a helper `getAuthorizationUrl(db, mcpServerId)` that uses the SDK's `startAuthorization()` to initiate discovery + PKCE and returns the authorization URL
+
+**Patterns to follow:**
+- MCP SDK's `OAuthClientProvider` interface contract
+- `server/src/services/mcp-client.ts` for service patterns
+
+**Test scenarios:**
+- Happy path: `tokens()` returns decrypted tokens from DB when active connection exists
+- Happy path: `saveTokens()` encrypts and stores tokens, creates connection with 'active' status
+- Happy path: `clientInformation()` returns client ID/secret from server's oauth_config
+- Happy path: `codeVerifier()` / `saveCodeVerifier()` round-trip through pending flows table
+- Edge case: `tokens()` returns undefined when no connection exists
+- Edge case: `saveTokens()` upserts (updates existing connection on re-auth)
+- Error path: `clientInformation()` throws when oauth_config not set on server
+- Integration: `redirectToAuthorization()` captures URL that can be retrieved
+
+**Verification:**
+- Provider satisfies the `OAuthClientProvider` interface contract
+- Tokens are encrypted at rest (inspect DB values)
+
+---
+
+- [ ] **Unit 5: OAuth Flow Service & API Routes**
+
+**Goal:** Implement the server-mediated OAuth flow endpoints: connect, callback, disconnect, status.
+
+**Requirements:** R1, R4, R5, R6, R7, R8
+
+**Dependencies:** Unit 4
+
+**Files:**
+- Create: `server/src/services/oauth-flow.ts`
+- Create: `server/src/routes/oauth.ts`
+- Modify: `server/src/routes/mcp-servers.ts`
+- Modify: `server/src/index.ts`
+- Test: `server/src/services/__tests__/oauth-flow.test.ts`
+
+**Approach:**
+- `oauth-flow.ts`:
+  - `initiateOAuthFlow(db, mcpServerId)`: Create `PawnOAuthClientProvider`, call SDK's `startAuthorization()` or `auth()` which triggers discovery + PKCE generation + stores verifier via provider. Capture the authorization URL from provider. Store pending flow metadata. Return `{ authUrl, state }`.
+  - `handleOAuthCallback(db, state, code)`: Look up pending flow by state, validate not expired. Create provider, call SDK's `exchangeAuthorization()` with the code — SDK handles token endpoint call and calls `saveTokens()`. Delete pending flow. Return success/error.
+  - `disconnectOAuth(db, mcpServerId)`: Delete oauth_connection row.
+- `oauth.ts`:
+  - `GET /api/oauth/callback` — handles browser redirect, calls `handleOAuthCallback()`, redirects to `/settings?oauth=success` or `?oauth=error&message=...`
+- Extend `mcp-servers.ts`:
+  - `POST /api/mcp-servers/:id/oauth/connect` — calls `initiateOAuthFlow()`, returns `{ authUrl, state }`
+  - `DELETE /api/mcp-servers/:id/oauth/disconnect` — calls `disconnectOAuth()`
+  - `GET /api/mcp-servers/:id/oauth/status` — reads oauth_connection status
+  - `PATCH /api/mcp-servers/:id` — extend to accept `oauthConfig` in body
+  - Update `rowToApi()` to join oauth_connection and mask client secret
+- Register oauth router in `server/src/index.ts`
+- Redirect URI: `http://localhost:${PORT}/api/oauth/callback` (overridable via `OAUTH_REDIRECT_URI` env var)
+
+**Patterns to follow:**
+- `server/src/routes/mcp-servers.ts` for route structure, error handling
+- `server/src/routes/webhooks.ts` for callback-style routes
+
+**Test scenarios:**
+- Happy path: POST /connect returns authUrl and state for configured MCP server
+- Happy path: GET /callback with valid state and code redirects to Settings with success
+- Happy path: DELETE /disconnect removes connection and returns 204
+- Happy path: GET /status returns current connection status
+- Happy path: PATCH updates oauthConfig (client_id, scopes)
+- Error path: POST /connect for server without oauth_config returns 400
+- Error path: GET /callback with invalid state returns error redirect
+- Error path: GET /callback with expired pending flow returns error redirect
+- Edge case: GET /status for server with no connection returns `{ status: 'disconnected' }`
+- Edge case: rowToApi includes oauthConnection status but never exposes tokens
+
+**Verification:**
+- Full OAuth flow works end-to-end via API
+- Callback redirects to UI with appropriate indicators
+
+---
+
+- [ ] **Unit 6: MCP Client OAuth Integration**
+
+**Goal:** Pass the `OAuthClientProvider` to HTTP transports so the SDK handles Bearer token injection and refresh automatically.
+
+**Requirements:** R1, R8
+
+**Dependencies:** Unit 4
+
+**Files:**
+- Modify: `server/src/services/mcp-client.ts`
+- Modify: `server/src/routes/mcp-servers.ts`
+
+**Approach:**
+- Modify `McpClientPool.connect()` to accept optional `db: Db` parameter
+- In `buildTransport()`, when transport is sse or streamable-http and server has an active oauth_connection:
+  - Create a `PawnOAuthClientProvider` instance
+  - Pass it as `authProvider` to `SSEClientTransport` or `StreamableHTTPClientTransport` constructor (the SDK already supports this)
+  - The SDK automatically includes Bearer tokens in requests and handles 401 retry with token refresh
+- Modify test/tools endpoints in mcp-servers route to pass `db` to pool.connect()
+- For pipeline execution: pass `db` through `ExecutionEngine` to `McpClientPool`
+- Non-OAuth servers: no change — authProvider is undefined, existing behavior preserved
+
+**Patterns to follow:**
+- `server/src/services/mcp-client.ts` existing `resolveEnvRefs()` pattern
+
+**Test scenarios:**
+- Happy path: OAuth-enabled server gets `authProvider` passed to transport
+- Happy path: non-OAuth server works unchanged (no authProvider)
+- Happy path: SDK automatically includes Bearer token in requests via authProvider
+- Edge case: static headers and OAuth auth coexist (headers field for non-auth headers, authProvider for Bearer)
+- Error path: expired token with refresh token — SDK auto-refreshes via authProvider
+- Error path: expired token without refresh token — SDK calls redirectToAuthorization
+- Integration: full flow — connect to MCP server with valid OAuth connection, list tools
+
+**Verification:**
+- OAuth-enabled MCP servers receive Bearer token in requests
+- Non-OAuth servers continue to work exactly as before
+
+---
+
+- [ ] **Unit 7: Background Token Refresh**
+
+**Goal:** Proactively refresh OAuth tokens before they expire, rather than waiting for a connection attempt.
+
+**Requirements:** R3, R10
+
+**Dependencies:** Unit 1, Unit 2, Unit 4
+
+**Files:**
+- Create: `server/src/services/oauth-refresh.ts`
+- Modify: `server/src/index.ts`
+- Test: `server/src/services/__tests__/oauth-refresh.test.ts`
+
+**Approach:**
+- `startOAuthRefreshPolling(db)` / `stopOAuthRefreshPolling()` — setInterval at 60-second intervals
+- Query oauth_connections where status='active' AND expires_at < now + 5 minutes AND refresh_token IS NOT NULL
+- For each: decrypt refresh token, call SDK's `refreshAuthorization()` with auth server URL from connection, encrypt and save new tokens
+- On success: update tokens, expires_at, last_refreshed_at, reset error state
+- On failure: increment retry count (stored in metadata jsonb), mark as 'error' after 3 consecutive failures with error_message
+- Emit WebSocket event (`ws.broadcast({ type: 'data-changed', entity: 'mcp-servers' })`) on status change so UI can update
+
+**Patterns to follow:**
+- `server/src/services/ollama-provider.ts` for `startOllamaPolling`/`stopOllamaPolling` interval pattern
+- `server/src/index.ts` for startup/shutdown lifecycle
+
+**Test scenarios:**
+- Happy path: token expiring in 3 minutes gets refreshed successfully
+- Happy path: refresh token rotation — new refresh token stored
+- Edge case: token expiring in 10 minutes is not refreshed (outside 5-min window)
+- Edge case: connection with no refresh token is skipped
+- Error path: refresh fails — connection marked 'error' after 3 retries
+- Error path: refresh endpoint unreachable — retried on next poll
+
+**Verification:**
+- Tokens refresh automatically before expiration
+- Failed refreshes degrade gracefully with status tracking
+
+---
+
+- [ ] **Unit 8: Frontend OAuth UI**
+
+**Goal:** Add OAuth connection management UI to the Settings page MCP server section.
+
+**Requirements:** R4, R5
+
+**Dependencies:** Unit 3, Unit 5
+
+**Files:**
+- Modify: `ui/src/pages/Settings.tsx`
+- Create: `ui/src/components/OAuthConnectionCard.tsx`
+- Modify: `ui/src/lib/api.ts`
+
+**Approach:**
+- Add API methods to `ui/src/lib/api.ts`:
+  - `initiateOAuthConnect(serverId): Promise<ApiOAuthConnectResponse>`
+  - `disconnectOAuth(serverId): Promise<void>`
+  - `updateMcpServerOAuthConfig(serverId, config): Promise<ApiMcpServer>`
+- New `OAuthConnectionCard` component:
+  - **Disconnected**: "Configure OAuth" section with client ID, client secret, scopes fields → Save → "Connect" button
+  - **Connecting**: Loading spinner during redirect
+  - **Connected**: Green status badge (`bg-emerald-500/20 text-emerald-300`), scopes, last refreshed, Disconnect button
+  - **Expired/Error**: Amber/red warning badge with error message, Reconnect button
+- Integrate into `McpServerRow` expanded view — show OAuthConnectionCard for HTTP-based servers (not stdio)
+- OAuth callback handling: on Settings page mount, check URL params for `?oauth=success` or `?oauth=error` → show toast → clean URL params
+- Use React Query `useQuery` for oauth status (included in `ApiMcpServer` response)
+
+**Patterns to follow:**
+- `ui/src/pages/Settings.tsx` existing `McpServerRow` component structure and styling
+- Design tokens: `pawn-gold-*`, `pawn-surface-*`, `bg-pawn-surface-900`, `rounded-card`
+- `useMutation` + `invalidateQueries` pattern for mutations
+
+**Test scenarios:**
+- Happy path: clicking "Connect" opens OAuth URL in new window/tab
+- Happy path: connected state shows green badge, scopes, and disconnect button
+- Happy path: disconnect button removes connection and UI updates
+- Edge case: OAuth section only appears for HTTP transports (not stdio)
+- Edge case: expired connection shows warning with reconnect option
+- Error path: OAuth callback error displays toast with error message
+
+**Verification:**
+- Full OAuth flow from UI: configure credentials → connect → authorize → see connected status
+- Status updates reflect after React Query refetch
+
+---
+
+- [ ] **Unit 9: Startup Lifecycle & Cleanup**
+
+**Goal:** Wire OAuth services into server startup/shutdown and add pending flow cleanup.
+
+**Requirements:** R3, R10
+
+**Dependencies:** Unit 1, Unit 7
+
+**Files:**
+- Modify: `server/src/index.ts`
+
+**Approach:**
+- Call `ensureEncryptionKey()` at startup before DB init — log key source (env var or file)
+- Call `startOAuthRefreshPolling(db)` after DB is ready
+- Call `stopOAuthRefreshPolling()` in shutdown handler
+- Startup cleanup: delete from `oauth_pending_flows` where `expires_at < now`
+- Register OAuth callback router: `app.use("/api", createOAuthRouter(db))`
+
+**Patterns to follow:**
+- `server/src/index.ts` existing `startOllamaPolling()`/`stopOllamaPolling()` lifecycle pattern
+
+**Test expectation:** none — integration wiring verified by end-to-end testing
+
+**Verification:**
+- Server starts cleanly with OAuth services initialized
+- Stale pending flows cleaned up automatically
+
+## System-Wide Impact
+
+- **Interaction graph:** The `authProvider` passed to SDK transports hooks into every MCP connection path — test/tools endpoints, pipeline execution engine, global agent. Any code path that connects to an MCP server automatically benefits.
+- **Error propagation:** OAuth errors surface as connection errors. The SDK's `auth()` handles 401 retry internally. Unrecoverable errors (revoked token, no refresh token) propagate as transport failures to the caller. UI shows status via OAuthConnectionCard.
+- **State lifecycle risks:** Pending OAuth flows that never complete need cleanup via TTL. Token refresh races serialized by in-process lock per connection ID. The SDK's own retry logic may attempt refresh simultaneously with our background poller — mitigate with optimistic locking on `last_refreshed_at`.
+- **API surface parity:** `oauthConfig` and `oauthConnection` are additive optional fields on `ApiMcpServer`. No breaking changes. The `headers` field continues to work for non-OAuth auth (API keys).
+- **Integration coverage:** Critical path: OAuth flow → encrypted storage → SDK authProvider → Bearer token in MCP request → successful tool call.
+- **Unchanged invariants:** stdio servers, non-OAuth HTTP servers, the `headers` field, env var resolution — all unchanged.
+
+## Risks & Dependencies
+
+| Risk | Mitigation |
+|------|------------|
+| Encryption key loss (DATA_DIR wiped) means all OAuth connections must be re-established | Document clearly. Auto-generate key is a convenience — production users should set `OAUTH_ENCRYPTION_KEY` env var. |
+| SDK's `OAuthClientProvider.redirectToAuthorization()` expects a browser redirect, not URL capture | Wrap or use `startAuthorization()` directly instead of `auth()`. Adapter pattern to capture URL. |
+| MCP servers with non-standard OAuth implementations | SDK handles spec compliance. Users can fall back to manual `headers` for non-compliant servers. |
+| Token refresh races between background poller and SDK's inline refresh | Optimistic locking on `last_refreshed_at`. Single-process assumption for v1. |
+| OAuth callback URL must be browser-accessible | Default to localhost:PORT. Document `OAUTH_REDIRECT_URI` for remote deployments. |
+
+## Sources & References
+
+- **Issue:** i75Corridor/pawn#64
+- **MCP Authorization Spec:** https://spec.modelcontextprotocol.io/specification/draft/basic/authorization/
+- **MCP SDK OAuth client:** `@modelcontextprotocol/sdk/client/auth.js` (v1.29.0, already installed)
+- Related issues: #62 (MCP env config), #63 (MCP HTTP custom headers)
+- Institutional learnings: `docs/solutions/best-practices/database-config-file-based-override-2026-04-06.md`, `docs/solutions/best-practices/adding-agent-tools-dual-system-architecture-2026-04-04.md`

--- a/docs/solutions/best-practices/adding-agent-tools-dual-system-architecture-2026-04-04.md
+++ b/docs/solutions/best-practices/adding-agent-tools-dual-system-architecture-2026-04-04.md
@@ -165,3 +165,4 @@ export function registerTriggerTools(server: McpServer, client: ApiClient): void
 - Issue #32: Add data_changed WebSocket listener in UI for real-time updates
 - Plan: `docs/plans/2026-04-04-001-feat-agent-tool-parity-plan.md`
 - Plan: `docs/plans/2026-04-03-001-feat-mcp-server-package-plan.md`
+- Related doc: `docs/solutions/best-practices/mcp-oauth-config-propagation-through-all-code-paths-2026-04-12.md` (ensuring new DB fields propagate through all config construction sites — complementary pattern for cross-cutting feature integration)

--- a/docs/solutions/best-practices/database-config-file-based-override-2026-04-06.md
+++ b/docs/solutions/best-practices/database-config-file-based-override-2026-04-06.md
@@ -179,3 +179,4 @@ async function startPostgres() {
 - Plan: `docs/plans/2026-04-06-003-feat-remote-database-config-plan.md`
 - Existing pattern: `server/src/services/custom-providers.ts` (`providers.json` file-read + cache pattern)
 - Related doc: `docs/solutions/best-practices/adding-agent-tools-dual-system-architecture-2026-04-04.md` (dual-system MCP/in-app architecture for settings tools)
+- Related doc: `docs/solutions/best-practices/mcp-oauth-config-propagation-through-all-code-paths-2026-04-12.md` (ensuring new DB fields reach all config consumers — this doc covers config *sourcing*, that doc covers config *consumption*)

--- a/docs/solutions/best-practices/mcp-oauth-config-propagation-through-all-code-paths-2026-04-12.md
+++ b/docs/solutions/best-practices/mcp-oauth-config-propagation-through-all-code-paths-2026-04-12.md
@@ -1,0 +1,128 @@
+---
+title: Propagate new DB fields through all config construction sites
+date: "2026-04-12"
+category: best-practices
+module: mcp-servers/oauth
+problem_type: best_practice
+component: tooling
+severity: medium
+applies_when:
+  - Adding a new column or field to a database-backed entity
+  - Implementing a cross-cutting feature (auth, logging, telemetry) that touches existing code paths
+  - Extending a config/options object that is constructed in multiple places
+  - Gating UI on data that may not be visible in the component's default render state
+tags:
+  - oauth
+  - mcp
+  - config-propagation
+  - integration
+  - field-omission
+  - cross-cutting-concern
+---
+
+# Propagate new DB fields through all config construction sites
+
+## Context
+
+When implementing MCP Client OAuth 2.1 support across the TypeScript/Express/React stack (15+ files, 9 implementation units), two integration bugs emerged after the feature was built. Both shared a root cause: the new `oauthConfig` field was correctly added to the database schema and correctly consumed by downstream logic, but the intermediate code paths that bridge the two were never updated. The feature worked in unit-level thinking but broke at the seams.
+
+**Bug 1**: Clicking "Test" on an OAuth-configured MCP server returned 401 because `oauthConfig` was not included in the config object passed to `pool.connect()`.
+
+**Bug 2**: The "Connect with OAuth" button was never visible because the `OAuthConnectionCard` was gated behind an unrelated `expanded` state.
+
+## Guidance
+
+**When you add a new field to a persisted entity, grep every place that entity's config object is constructed — not just where it is consumed.**
+
+Database columns are read in many places. If your ORM row is destructured or cherry-picked into a plain object before being passed to business logic, every such construction site must include the new field. The compiler will not catch omissions in optional/JSONB fields.
+
+### Backend: propagate new fields through all config construction sites
+
+Before (field omitted at construction):
+```typescript
+// server/src/routes/mcp-servers.ts — test endpoint
+const tools = await pool.connect({
+  id: row.id,
+  name: row.name,
+  transport: row.transport as "stdio" | "sse" | "streamable-http",
+  command: row.command ?? undefined,
+  args: (row.args as string[] | null) ?? [],
+  url: row.url ?? undefined,
+  headers: (row.headers as Record<string, string> | null) ?? {},
+  env: (row.env as Record<string, string> | null) ?? {},
+  // oauthConfig NOT included — silent failure
+});
+```
+
+After:
+```typescript
+const tools = await pool.connect({
+  id: row.id,
+  name: row.name,
+  transport: row.transport as "stdio" | "sse" | "streamable-http",
+  command: row.command ?? undefined,
+  args: (row.args as string[] | null) ?? [],
+  url: row.url ?? undefined,
+  headers: (row.headers as Record<string, string> | null) ?? {},
+  env: (row.env as Record<string, string> | null) ?? {},
+  oauthConfig: (row.oauthConfig as {
+    clientId: string; clientSecret?: string; scopes?: string[];
+  } | null) ?? undefined,
+});
+```
+
+### Frontend: do not gate primary actions behind secondary interactions
+
+Before (OAuth button hidden until row is expanded):
+```tsx
+{expanded && (server.transport === "sse" || server.transport === "streamable-http") && (
+  <OAuthConnectionCard server={server} />
+)}
+```
+
+After (visible whenever applicable):
+```tsx
+{(server.transport === "sse" || server.transport === "streamable-http") && server.oauthConfig && (
+  <OAuthConnectionCard server={server} />
+)}
+```
+
+## Why This Matters
+
+1. **Silent failures are the most expensive bugs.** The `oauthConfig` omission produced a 401 at runtime with no build error, no type error, and no test failure — the field was optional, so TypeScript was satisfied with `undefined`. The only signal was the HTTP error from the remote server.
+
+2. **Users cannot act on what they cannot see.** The OAuth connect button was the single entry point for the entire OAuth flow. Hiding it behind an expand toggle meant users would fail to authenticate until they discovered the hidden panel by accident.
+
+3. **Cross-cutting features have multiplicative integration surface.** A feature touching N endpoints and M UI components has N+M potential omission sites. Each one is an independent failure mode that will not surface until that specific code path executes with real data.
+
+## When to Apply
+
+- You are adding a column to a database table and the corresponding entity is read in more than one route or service method
+- You are building a feature that modifies a shared config/options type, especially when the type uses optional fields or JSONB
+- You are adding UI for a new capability — ask whether the user needs to discover it or whether it should be immediately visible
+- You are working in a codebase where entity objects are constructed via manual field-picking rather than spread or ORM hydration (the risk is highest here because the compiler cannot enforce completeness on partial object literals with optional properties)
+
+## Examples
+
+### Example 1: Backend config propagation
+
+**Symptom**: `StreamableHTTPError: {"error":"invalid_token","error_description":"Missing Authorization header"}`
+
+**Investigation**: `McpClientPool.connect()` correctly checked `config.oauthConfig` and created an auth provider when present. The `mcp_servers` table had `oauthConfig` populated. The gap was in `server/src/routes/mcp-servers.ts` where the config object was constructed by cherry-picking fields from the DB row — `oauthConfig` was not listed.
+
+**Prevention**: After adding any new field, run `grep -rn 'id: row.id'` (or equivalent pattern for your entity construction) to find every site that builds the config object. Each one needs the new field.
+
+### Example 2: UI visibility
+
+**Symptom**: Users never saw the "Connect with OAuth" button.
+
+**Investigation**: `OAuthConnectionCard` was rendered inside `{expanded && ...}` in `McpServerRow`. The row defaults to collapsed. The OAuth card was the primary action for OAuth-configured servers, not supplementary detail.
+
+**Prevention**: When a new feature's primary CTA is placed inside an existing container, verify that the container's default visibility matches the action's importance. Primary actions belong at the top level; supplementary details can live behind expand/collapse.
+
+## Related
+
+- `docs/solutions/best-practices/adding-agent-tools-dual-system-architecture-2026-04-04.md` — covers tool-level parity (registration in both in-app and MCP systems); complementary pattern for feature propagation
+- `docs/solutions/best-practices/database-config-file-based-override-2026-04-06.md` — covers config *sourcing* (file → env → DB resolution); this doc covers config *consumption* (ensuring new fields reach all consumers)
+- i75Corridor/pawn#64 — MCP client OAuth support feature that prompted these learnings
+- i75Corridor/pawn#63 — MCP client HTTP custom headers (same pattern: new fields that must propagate)

--- a/packages/db/src/migrations/0017_stiff_veda.sql
+++ b/packages/db/src/migrations/0017_stiff_veda.sql
@@ -1,0 +1,35 @@
+CREATE TABLE "oauth_connections" (
+	"id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+	"mcp_server_id" uuid NOT NULL,
+	"access_token" text NOT NULL,
+	"refresh_token" text,
+	"expires_at" timestamp with time zone,
+	"scope" text,
+	"token_type" text DEFAULT 'Bearer' NOT NULL,
+	"status" text DEFAULT 'active' NOT NULL,
+	"connected_at" timestamp with time zone DEFAULT now() NOT NULL,
+	"last_refreshed_at" timestamp with time zone,
+	"error_message" text,
+	"auth_server_url" text,
+	"client_registration" jsonb,
+	"discovery_state" jsonb,
+	CONSTRAINT "oauth_connections_mcp_server_id_unique" UNIQUE("mcp_server_id")
+);
+--> statement-breakpoint
+CREATE TABLE "oauth_pending_flows" (
+	"id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+	"mcp_server_id" uuid NOT NULL,
+	"state" text NOT NULL,
+	"code_verifier" text NOT NULL,
+	"redirect_uri" text NOT NULL,
+	"scopes" text,
+	"resource_uri" text,
+	"auth_server_metadata" jsonb,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL,
+	"expires_at" timestamp with time zone DEFAULT now() + interval '10 minutes' NOT NULL,
+	CONSTRAINT "oauth_pending_flows_state_unique" UNIQUE("state")
+);
+--> statement-breakpoint
+ALTER TABLE "mcp_servers" ADD COLUMN "oauth_config" jsonb;--> statement-breakpoint
+ALTER TABLE "oauth_connections" ADD CONSTRAINT "oauth_connections_mcp_server_id_mcp_servers_id_fk" FOREIGN KEY ("mcp_server_id") REFERENCES "public"."mcp_servers"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "oauth_pending_flows" ADD CONSTRAINT "oauth_pending_flows_mcp_server_id_mcp_servers_id_fk" FOREIGN KEY ("mcp_server_id") REFERENCES "public"."mcp_servers"("id") ON DELETE cascade ON UPDATE no action;

--- a/packages/db/src/migrations/meta/0017_snapshot.json
+++ b/packages/db/src/migrations/meta/0017_snapshot.json
@@ -1,0 +1,1812 @@
+{
+  "id": "14ca15d2-152c-447e-bd16-ee9682a304ed",
+  "prevId": "ca232c1e-aa52-4d85-8e4f-a8f7c1be3bcc",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.pipeline_steps": {
+      "name": "pipeline_steps",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "pipeline_id": {
+          "name": "pipeline_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "step_index": {
+          "name": "step_index",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "skill_name": {
+          "name": "skill_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "prompt_template": {
+          "name": "prompt_template",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "timeout_seconds": {
+          "name": "timeout_seconds",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 300
+        },
+        "approval_required": {
+          "name": "approval_required",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "retry_config": {
+          "name": "retry_config",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "pipeline_steps_pipeline_idx": {
+          "name": "pipeline_steps_pipeline_idx",
+          "columns": [
+            {
+              "expression": "pipeline_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "pipeline_steps_pipeline_id_pipelines_id_fk": {
+          "name": "pipeline_steps_pipeline_id_pipelines_id_fk",
+          "tableFrom": "pipeline_steps",
+          "tableTo": "pipelines",
+          "columnsFrom": [
+            "pipeline_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "pipeline_steps_pipeline_step_idx": {
+          "name": "pipeline_steps_pipeline_step_idx",
+          "nullsNotDistinct": false,
+          "columns": [
+            "pipeline_id",
+            "step_index"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.pipelines": {
+      "name": "pipelines",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "input_schema": {
+          "name": "input_schema",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "system_prompt": {
+          "name": "system_prompt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "model_provider": {
+          "name": "model_provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "model_name": {
+          "name": "model_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.pipeline_runs": {
+      "name": "pipeline_runs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "pipeline_id": {
+          "name": "pipeline_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'queued'"
+        },
+        "input_params": {
+          "name": "input_params",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "output": {
+          "name": "output",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "trigger_type": {
+          "name": "trigger_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'manual'"
+        },
+        "trigger_detail": {
+          "name": "trigger_detail",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "finished_at": {
+          "name": "finished_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "pipeline_runs_pipeline_status_idx": {
+          "name": "pipeline_runs_pipeline_status_idx",
+          "columns": [
+            {
+              "expression": "pipeline_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "pipeline_runs_created_at_idx": {
+          "name": "pipeline_runs_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "pipeline_runs_pipeline_id_pipelines_id_fk": {
+          "name": "pipeline_runs_pipeline_id_pipelines_id_fk",
+          "tableFrom": "pipeline_runs",
+          "tableTo": "pipelines",
+          "columnsFrom": [
+            "pipeline_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.step_runs": {
+      "name": "step_runs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "pipeline_run_id": {
+          "name": "pipeline_run_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "step_index": {
+          "name": "step_index",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'queued'"
+        },
+        "input": {
+          "name": "input",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "output": {
+          "name": "output",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "session_id_before": {
+          "name": "session_id_before",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "session_id_after": {
+          "name": "session_id_after",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "usage_json": {
+          "name": "usage_json",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "finished_at": {
+          "name": "finished_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "step_runs_run_step_idx": {
+          "name": "step_runs_run_step_idx",
+          "columns": [
+            {
+              "expression": "pipeline_run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "step_index",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "step_runs_pipeline_run_id_pipeline_runs_id_fk": {
+          "name": "step_runs_pipeline_run_id_pipeline_runs_id_fk",
+          "tableFrom": "step_runs",
+          "tableTo": "pipeline_runs",
+          "columnsFrom": [
+            "pipeline_run_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.step_run_events": {
+      "name": "step_run_events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "step_run_id": {
+          "name": "step_run_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "seq": {
+          "name": "seq",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "event_type": {
+          "name": "event_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "message": {
+          "name": "message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "payload": {
+          "name": "payload",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "step_run_events_step_seq_idx": {
+          "name": "step_run_events_step_seq_idx",
+          "columns": [
+            {
+              "expression": "step_run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "seq",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "step_run_events_step_run_id_step_runs_id_fk": {
+          "name": "step_run_events_step_run_id_step_runs_id_fk",
+          "tableFrom": "step_run_events",
+          "tableTo": "step_runs",
+          "columnsFrom": [
+            "step_run_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.triggers": {
+      "name": "triggers",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "pipeline_id": {
+          "name": "pipeline_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "cron_expression": {
+          "name": "cron_expression",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "timezone": {
+          "name": "timezone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'UTC'"
+        },
+        "next_run_at": {
+          "name": "next_run_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_fired_at": {
+          "name": "last_fired_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "webhook_public_id": {
+          "name": "webhook_public_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "webhook_secret": {
+          "name": "webhook_secret",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "channel_type": {
+          "name": "channel_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "channel_config": {
+          "name": "channel_config",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "default_inputs": {
+          "name": "default_inputs",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "triggers_pipeline_idx": {
+          "name": "triggers_pipeline_idx",
+          "columns": [
+            {
+              "expression": "pipeline_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "triggers_enabled_type_idx": {
+          "name": "triggers_enabled_type_idx",
+          "columns": [
+            {
+              "expression": "enabled",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "triggers_pipeline_id_pipelines_id_fk": {
+          "name": "triggers_pipeline_id_pipelines_id_fk",
+          "tableFrom": "triggers",
+          "tableTo": "pipelines",
+          "columnsFrom": [
+            "pipeline_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "triggers_webhook_public_id_unique": {
+          "name": "triggers_webhook_public_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "webhook_public_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.approvals": {
+      "name": "approvals",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "pipeline_run_id": {
+          "name": "pipeline_run_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "step_run_id": {
+          "name": "step_run_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "payload": {
+          "name": "payload",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "decision_note": {
+          "name": "decision_note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "decided_at": {
+          "name": "decided_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "approvals_status_idx": {
+          "name": "approvals_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "approvals_pipeline_run_idx": {
+          "name": "approvals_pipeline_run_idx",
+          "columns": [
+            {
+              "expression": "pipeline_run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "approvals_pipeline_run_id_pipeline_runs_id_fk": {
+          "name": "approvals_pipeline_run_id_pipeline_runs_id_fk",
+          "tableFrom": "approvals",
+          "tableTo": "pipeline_runs",
+          "columnsFrom": [
+            "pipeline_run_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "approvals_step_run_id_step_runs_id_fk": {
+          "name": "approvals_step_run_id_step_runs_id_fk",
+          "tableFrom": "approvals",
+          "tableTo": "step_runs",
+          "columnsFrom": [
+            "step_run_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.cost_events": {
+      "name": "cost_events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "step_run_id": {
+          "name": "step_run_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "skill_name": {
+          "name": "skill_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "pipeline_run_id": {
+          "name": "pipeline_run_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "input_tokens": {
+          "name": "input_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "output_tokens": {
+          "name": "output_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "cost_cents": {
+          "name": "cost_cents",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "occurred_at": {
+          "name": "occurred_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "cost_events_skill_date_idx": {
+          "name": "cost_events_skill_date_idx",
+          "columns": [
+            {
+              "expression": "skill_name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "occurred_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "cost_events_pipeline_run_idx": {
+          "name": "cost_events_pipeline_run_idx",
+          "columns": [
+            {
+              "expression": "pipeline_run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "cost_events_step_run_id_step_runs_id_fk": {
+          "name": "cost_events_step_run_id_step_runs_id_fk",
+          "tableFrom": "cost_events",
+          "tableTo": "step_runs",
+          "columnsFrom": [
+            "step_run_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "cost_events_pipeline_run_id_pipeline_runs_id_fk": {
+          "name": "cost_events_pipeline_run_id_pipeline_runs_id_fk",
+          "tableFrom": "cost_events",
+          "tableTo": "pipeline_runs",
+          "columnsFrom": [
+            "pipeline_run_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.budget_policies": {
+      "name": "budget_policies",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "scope_type": {
+          "name": "scope_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scope_id": {
+          "name": "scope_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "amount_cents": {
+          "name": "amount_cents",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "window_kind": {
+          "name": "window_kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'calendar_month'"
+        },
+        "warn_percent": {
+          "name": "warn_percent",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 80
+        },
+        "hard_stop_enabled": {
+          "name": "hard_stop_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "budget_policies_scope_idx": {
+          "name": "budget_policies_scope_idx",
+          "columns": [
+            {
+              "expression": "scope_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "scope_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.settings": {
+      "name": "settings",
+      "schema": "",
+      "columns": {
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.installed_blueprints": {
+      "name": "installed_blueprints",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "repo_url": {
+          "name": "repo_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "repo_full_name": {
+          "name": "repo_full_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "pipeline_id": {
+          "name": "pipeline_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "installed_ref": {
+          "name": "installed_ref",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "latest_ref": {
+          "name": "latest_ref",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "update_available": {
+          "name": "update_available",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "repo_not_found": {
+          "name": "repo_not_found",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "local_path": {
+          "name": "local_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "skills": {
+          "name": "skills",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "installed_at": {
+          "name": "installed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "last_checked_at": {
+          "name": "last_checked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "installed_blueprints_pipeline_id_pipelines_id_fk": {
+          "name": "installed_blueprints_pipeline_id_pipelines_id_fk",
+          "tableFrom": "installed_blueprints",
+          "tableTo": "pipelines",
+          "columnsFrom": [
+            "pipeline_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "installed_blueprints_repo_url_unique": {
+          "name": "installed_blueprints_repo_url_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "repo_url"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.blueprint_security_checks": {
+      "name": "blueprint_security_checks",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "blueprint_id": {
+          "name": "blueprint_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "repo_url": {
+          "name": "repo_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "level": {
+          "name": "level",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "findings": {
+          "name": "findings",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "scanned_files": {
+          "name": "scanned_files",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "scanned_at": {
+          "name": "scanned_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "blueprint_security_checks_blueprint_id_installed_blueprints_id_fk": {
+          "name": "blueprint_security_checks_blueprint_id_installed_blueprints_id_fk",
+          "tableFrom": "blueprint_security_checks",
+          "tableTo": "installed_blueprints",
+          "columnsFrom": [
+            "blueprint_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.mcp_servers": {
+      "name": "mcp_servers",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "transport": {
+          "name": "transport",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "command": {
+          "name": "command",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "args": {
+          "name": "args",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'[]'::jsonb"
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "headers": {
+          "name": "headers",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'{}'::jsonb"
+        },
+        "env": {
+          "name": "env",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'{}'::jsonb"
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'manual'"
+        },
+        "source_blueprint_id": {
+          "name": "source_blueprint_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "oauth_config": {
+          "name": "oauth_config",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "mcp_servers_source_blueprint_id_installed_blueprints_id_fk": {
+          "name": "mcp_servers_source_blueprint_id_installed_blueprints_id_fk",
+          "tableFrom": "mcp_servers",
+          "tableTo": "installed_blueprints",
+          "columnsFrom": [
+            "source_blueprint_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "mcp_servers_name_unique": {
+          "name": "mcp_servers_name_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "name"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.oauth_connections": {
+      "name": "oauth_connections",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "mcp_server_id": {
+          "name": "mcp_server_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "token_type": {
+          "name": "token_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'Bearer'"
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "connected_at": {
+          "name": "connected_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "last_refreshed_at": {
+          "name": "last_refreshed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "auth_server_url": {
+          "name": "auth_server_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "client_registration": {
+          "name": "client_registration",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "discovery_state": {
+          "name": "discovery_state",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "oauth_connections_mcp_server_id_mcp_servers_id_fk": {
+          "name": "oauth_connections_mcp_server_id_mcp_servers_id_fk",
+          "tableFrom": "oauth_connections",
+          "tableTo": "mcp_servers",
+          "columnsFrom": [
+            "mcp_server_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "oauth_connections_mcp_server_id_unique": {
+          "name": "oauth_connections_mcp_server_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "mcp_server_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.oauth_pending_flows": {
+      "name": "oauth_pending_flows",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "mcp_server_id": {
+          "name": "mcp_server_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "state": {
+          "name": "state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "code_verifier": {
+          "name": "code_verifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "redirect_uri": {
+          "name": "redirect_uri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scopes": {
+          "name": "scopes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resource_uri": {
+          "name": "resource_uri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "auth_server_metadata": {
+          "name": "auth_server_metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now() + interval '10 minutes'"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "oauth_pending_flows_mcp_server_id_mcp_servers_id_fk": {
+          "name": "oauth_pending_flows_mcp_server_id_mcp_servers_id_fk",
+          "tableFrom": "oauth_pending_flows",
+          "tableTo": "mcp_servers",
+          "columnsFrom": [
+            "mcp_server_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "oauth_pending_flows_state_unique": {
+          "name": "oauth_pending_flows_state_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "state"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.pipeline_versions": {
+      "name": "pipeline_versions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "pipeline_id": {
+          "name": "pipeline_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "version_number": {
+          "name": "version_number",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "snapshot": {
+          "name": "snapshot",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "change_summary": {
+          "name": "change_summary",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "pipeline_versions_pipeline_id_pipelines_id_fk": {
+          "name": "pipeline_versions_pipeline_id_pipelines_id_fk",
+          "tableFrom": "pipeline_versions",
+          "tableTo": "pipelines",
+          "columnsFrom": [
+            "pipeline_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "pipeline_versions_pipeline_id_version_number_unique": {
+          "name": "pipeline_versions_pipeline_id_version_number_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "pipeline_id",
+            "version_number"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/packages/db/src/migrations/meta/_journal.json
+++ b/packages/db/src/migrations/meta/_journal.json
@@ -120,6 +120,13 @@
       "when": 1775661620284,
       "tag": "0016_mature_famine",
       "breakpoints": true
+    },
+    {
+      "idx": 17,
+      "version": "7",
+      "when": 1775743040688,
+      "tag": "0017_stiff_veda",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/db/src/schema/index.ts
+++ b/packages/db/src/schema/index.ts
@@ -9,4 +9,5 @@ export * from "./settings.js";
 export * from "./blueprints.js";
 export * from "./security-checks.js";
 export * from "./mcp-servers.js";
+export * from "./oauth-connections.js";
 export * from "./pipeline-versions.js";

--- a/packages/db/src/schema/mcp-servers.ts
+++ b/packages/db/src/schema/mcp-servers.ts
@@ -14,6 +14,7 @@ export const mcpServers = pgTable("mcp_servers", {
   source: text("source").notNull().default("manual"), // 'manual' | 'blueprint'
   sourceBlueprintId: uuid("source_blueprint_id").references(() => installedBlueprints.id, { onDelete: "set null" }),
   metadata: jsonb("metadata").$type<Record<string, unknown>>(),
+  oauthConfig: jsonb("oauth_config").$type<{ clientId: string; clientSecret?: string; scopes?: string[] }>(),
   createdAt: timestamp("created_at", { withTimezone: true }).notNull().defaultNow(),
   updatedAt: timestamp("updated_at", { withTimezone: true }).notNull().defaultNow(),
 });

--- a/packages/db/src/schema/oauth-connections.ts
+++ b/packages/db/src/schema/oauth-connections.ts
@@ -1,0 +1,40 @@
+import { pgTable, uuid, text, jsonb, timestamp } from "drizzle-orm/pg-core";
+import { mcpServers } from "./mcp-servers.js";
+import { sql } from "drizzle-orm";
+
+export const oauthConnections = pgTable("oauth_connections", {
+  id: uuid("id").primaryKey().defaultRandom(),
+  mcpServerId: uuid("mcp_server_id")
+    .notNull()
+    .unique()
+    .references(() => mcpServers.id, { onDelete: "cascade" }),
+  accessToken: text("access_token").notNull(),
+  refreshToken: text("refresh_token"),
+  expiresAt: timestamp("expires_at", { withTimezone: true }),
+  scope: text("scope"),
+  tokenType: text("token_type").notNull().default("Bearer"),
+  status: text("status").notNull().default("active"), // 'active' | 'expired' | 'revoked' | 'error'
+  connectedAt: timestamp("connected_at", { withTimezone: true }).notNull().defaultNow(),
+  lastRefreshedAt: timestamp("last_refreshed_at", { withTimezone: true }),
+  errorMessage: text("error_message"),
+  authServerUrl: text("auth_server_url"),
+  clientRegistration: jsonb("client_registration"),
+  discoveryState: jsonb("discovery_state"),
+});
+
+export const oauthPendingFlows = pgTable("oauth_pending_flows", {
+  id: uuid("id").primaryKey().defaultRandom(),
+  mcpServerId: uuid("mcp_server_id")
+    .notNull()
+    .references(() => mcpServers.id, { onDelete: "cascade" }),
+  state: text("state").unique().notNull(),
+  codeVerifier: text("code_verifier").notNull(),
+  redirectUri: text("redirect_uri").notNull(),
+  scopes: text("scopes"),
+  resourceUri: text("resource_uri"),
+  authServerMetadata: jsonb("auth_server_metadata"),
+  createdAt: timestamp("created_at", { withTimezone: true }).notNull().defaultNow(),
+  expiresAt: timestamp("expires_at", { withTimezone: true })
+    .notNull()
+    .default(sql`now() + interval '10 minutes'`),
+});

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -290,6 +290,31 @@ export interface DatabaseConfig {
   sslMode?: "disable" | "allow" | "prefer" | "require" | "verify-ca" | "verify-full";
 }
 
+export type ApiOAuthStatus = 'active' | 'expired' | 'revoked' | 'error' | 'disconnected';
+
+export interface ApiOAuthConnection {
+  id: string;
+  mcpServerId: string;
+  status: ApiOAuthStatus;
+  scope?: string;
+  tokenType: string;
+  connectedAt: string;
+  lastRefreshedAt?: string;
+  expiresAt?: string;
+  errorMessage?: string;
+}
+
+export interface ApiOAuthConfig {
+  clientId: string;
+  hasClientSecret: boolean;  // Never expose raw secret
+  scopes?: string[];
+}
+
+export interface ApiOAuthConnectResponse {
+  authUrl: string;
+  state: string;
+}
+
 export interface ApiMcpServer {
   id: string;
   name: string;
@@ -305,6 +330,8 @@ export interface ApiMcpServer {
   metadata?: {
     envRequirements?: McpEnvRequirement[];
   };
+  oauthConfig?: ApiOAuthConfig;
+  oauthConnection?: ApiOAuthConnection;
 }
 
 export interface ApiMcpTool {

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -37,6 +37,10 @@ import { startOllamaPolling, stopOllamaPolling } from "./services/ollama-provide
 import { createCustomProvidersRouter } from "./routes/custom-providers.js";
 import { loadCustomProviders } from "./services/custom-providers.js";
 import { loadDatabaseConfig } from "./services/database-config.js";
+import { ensureEncryptionKey } from "./services/oauth-crypto.js";
+import { startOAuthRefreshPolling, stopOAuthRefreshPolling } from "./services/oauth-refresh.js";
+import { oauthPendingFlows } from "@pawn/db";
+import { lte } from "drizzle-orm";
 
 const PORT = parseInt(process.env.PORT ?? "3009", 10);
 const DATA_DIR = process.env.DATA_DIR ?? join(process.cwd(), "..", ".data");
@@ -128,6 +132,9 @@ async function startPostgres(): Promise<{ url: string; stop: () => Promise<void>
 }
 
 async function main() {
+  const keySource = ensureEncryptionKey(DATA_DIR);
+  console.log(`[OAuth] Encryption key loaded from ${keySource}`);
+
   const { url: dbUrl, stop: stopPostgres } = await startPostgres();
 
   const db = createDb(dbUrl);
@@ -225,6 +232,16 @@ async function main() {
     void startOllamaPolling();
   }
 
+  // Start OAuth token refresh polling
+  startOAuthRefreshPolling(db);
+  console.log("[OAuth] Token refresh polling started");
+
+  // Clean up expired OAuth pending flows
+  const cleaned = await db.delete(oauthPendingFlows).where(lte(oauthPendingFlows.expiresAt, new Date())).returning();
+  if (cleaned.length > 0) {
+    console.log(`[OAuth] Cleaned up ${cleaned.length} expired pending flow(s)`);
+  }
+
   httpServer.listen(PORT, () => {
     console.log(`[Server] Listening on http://localhost:${PORT}`);
     console.log(`[Server] WebSocket on ws://localhost:${PORT}`);
@@ -235,6 +252,7 @@ async function main() {
     engine.stop();
     triggers.stop();
     stopOllamaPolling();
+    stopOAuthRefreshPolling();
     httpServer.close();
     await stopPostgres();
     process.exit(0);

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -27,6 +27,7 @@ import { createWebhooksRouter } from "./routes/webhooks.js";
 import { createSkillsRouter } from "./routes/skills.js";
 import { createBlueprintsRouter } from "./routes/blueprints.js";
 import { makeMcpServersRouter } from "./routes/mcp-servers.js";
+import { createOAuthRouter } from "./routes/oauth.js";
 import { createModelsRouter } from "./routes/models.js";
 import { createLogsRouter } from "./routes/logs.js";
 import { ChannelManager } from "./services/channel-manager.js";
@@ -172,6 +173,7 @@ async function main() {
   app.use("/api", createFilesRouter());
   app.use("/api", createSkillsRouter());
   app.use("/api", makeMcpServersRouter(db));
+  app.use("/api", createOAuthRouter(db));
   app.use("/api", createModelsRouter());
   app.use("/api", createLogsRouter());
 

--- a/server/src/routes/mcp-servers.ts
+++ b/server/src/routes/mcp-servers.ts
@@ -126,6 +126,7 @@ export function makeMcpServersRouter(db: Db): Router {
   // POST /api/mcp-servers
   router.post("/mcp-servers", async (req, res) => {
     const { name, transport, command, args, url, headers, env } = req.body as Partial<ApiMcpServer>;
+    const oauthConfigBody = req.body.oauthConfig as { clientId: string; clientSecret?: string; scopes?: string[] } | undefined;
     if (!name || !transport) { res.status(400).json({ error: "name and transport are required" }); return; }
     try {
       const [row] = await db.insert(mcpServers).values({
@@ -137,6 +138,7 @@ export function makeMcpServersRouter(db: Db): Router {
         headers: headers ?? {},
         env: env ?? {},
         source: "manual",
+        ...(oauthConfigBody ? { oauthConfig: oauthConfigBody } : {}),
       }).returning();
       res.status(201).json(rowToApi(row));
     } catch (err: any) {

--- a/server/src/routes/mcp-servers.ts
+++ b/server/src/routes/mcp-servers.ts
@@ -195,6 +195,7 @@ export function makeMcpServersRouter(db: Db): Router {
         url: row.url ?? undefined,
         headers: (row.headers as Record<string, string> | null) ?? {},
         env: (row.env as Record<string, string> | null) ?? {},
+        oauthConfig: (row.oauthConfig as { clientId: string; clientSecret?: string; scopes?: string[] } | null) ?? undefined,
       });
       res.json({ connected: true, tools });
     } catch (err) {
@@ -287,6 +288,7 @@ export function makeMcpServersRouter(db: Db): Router {
         url: row.url ?? undefined,
         headers: (row.headers as Record<string, string> | null) ?? {},
         env: (row.env as Record<string, string> | null) ?? {},
+        oauthConfig: (row.oauthConfig as { clientId: string; clientSecret?: string; scopes?: string[] } | null) ?? undefined,
       });
       res.json(tools);
     } catch (err) {

--- a/server/src/routes/mcp-servers.ts
+++ b/server/src/routes/mcp-servers.ts
@@ -182,6 +182,7 @@ export function makeMcpServersRouter(db: Db): Router {
     if (!row) { res.status(404).json({ error: "Not found" }); return; }
 
     const pool = new McpClientPool();
+    pool.setDb(db);
     try {
       const tools = await pool.connect({
         id: row.id,
@@ -273,6 +274,7 @@ export function makeMcpServersRouter(db: Db): Router {
     if (!row) { res.status(404).json({ error: "Not found" }); return; }
 
     const pool = new McpClientPool();
+    pool.setDb(db);
     try {
       const tools = await pool.connect({
         id: row.id,

--- a/server/src/routes/mcp-servers.ts
+++ b/server/src/routes/mcp-servers.ts
@@ -1,12 +1,42 @@
 import { Router } from "express";
 import { eq } from "drizzle-orm";
 import type { Db } from "@pawn/db";
-import { mcpServers } from "@pawn/db";
-import type { ApiMcpServer } from "@pawn/shared";
+import { mcpServers, oauthConnections } from "@pawn/db";
+import type { ApiMcpServer, ApiOAuthConfig, ApiOAuthConnection } from "@pawn/shared";
 import { McpClientPool } from "../services/mcp-client.js";
 import { detectEnvVars } from "../services/mcp-env-detector.js";
+import { initiateOAuthFlow, disconnectOAuth } from "../services/oauth-flow.js";
 
-function rowToApi(row: typeof mcpServers.$inferSelect): ApiMcpServer {
+function rowToApi(
+  row: typeof mcpServers.$inferSelect,
+  oauthRow?: typeof oauthConnections.$inferSelect | null,
+): ApiMcpServer {
+  const oauthCfg = row.oauthConfig as { clientId: string; clientSecret?: string; scopes?: string[] } | null;
+
+  let oauthConfig: ApiOAuthConfig | undefined;
+  if (oauthCfg) {
+    oauthConfig = {
+      clientId: oauthCfg.clientId,
+      hasClientSecret: !!oauthCfg.clientSecret,
+      scopes: oauthCfg.scopes,
+    };
+  }
+
+  let oauthConnection: ApiOAuthConnection | undefined;
+  if (oauthRow && oauthRow.status) {
+    oauthConnection = {
+      id: oauthRow.id,
+      mcpServerId: oauthRow.mcpServerId,
+      status: oauthRow.status as ApiOAuthConnection["status"],
+      scope: oauthRow.scope ?? undefined,
+      tokenType: oauthRow.tokenType,
+      connectedAt: oauthRow.connectedAt.toISOString(),
+      lastRefreshedAt: oauthRow.lastRefreshedAt?.toISOString(),
+      expiresAt: oauthRow.expiresAt?.toISOString(),
+      errorMessage: oauthRow.errorMessage ?? undefined,
+    };
+  }
+
   return {
     id: row.id,
     name: row.name,
@@ -20,6 +50,8 @@ function rowToApi(row: typeof mcpServers.$inferSelect): ApiMcpServer {
     source: row.source as ApiMcpServer["source"],
     sourceBlueprintId: row.sourceBlueprintId ?? undefined,
     metadata: (row.metadata as ApiMcpServer["metadata"]) ?? undefined,
+    oauthConfig,
+    oauthConnection,
   };
 }
 
@@ -28,8 +60,13 @@ export function makeMcpServersRouter(db: Db): Router {
 
   // GET /api/mcp-servers
   router.get("/mcp-servers", async (_req, res) => {
-    const rows = await db.select().from(mcpServers).orderBy(mcpServers.name);
-    res.json(rows.map(rowToApi));
+    const rows = await db
+      .select()
+      .from(mcpServers)
+      .leftJoin(oauthConnections, eq(mcpServers.id, oauthConnections.mcpServerId))
+      .orderBy(mcpServers.name);
+
+    res.json(rows.map((r) => rowToApi(r.mcp_servers, r.oauth_connections)));
   });
 
   // POST /api/mcp-servers/detect-env
@@ -75,9 +112,15 @@ export function makeMcpServersRouter(db: Db): Router {
 
   // GET /api/mcp-servers/:id
   router.get("/mcp-servers/:id", async (req, res) => {
-    const row = await db.query.mcpServers.findFirst({ where: eq(mcpServers.id, req.params.id) });
-    if (!row) { res.status(404).json({ error: "Not found" }); return; }
-    res.json(rowToApi(row));
+    const rows = await db
+      .select()
+      .from(mcpServers)
+      .leftJoin(oauthConnections, eq(mcpServers.id, oauthConnections.mcpServerId))
+      .where(eq(mcpServers.id, req.params.id))
+      .limit(1);
+
+    if (rows.length === 0) { res.status(404).json({ error: "Not found" }); return; }
+    res.json(rowToApi(rows[0].mcp_servers, rows[0].oauth_connections));
   });
 
   // POST /api/mcp-servers
@@ -108,6 +151,8 @@ export function makeMcpServersRouter(db: Db): Router {
   // PATCH /api/mcp-servers/:id
   router.patch("/mcp-servers/:id", async (req, res) => {
     const { name, transport, command, args, url, headers, env, enabled } = req.body as Partial<ApiMcpServer>;
+    const oauthConfigBody = req.body.oauthConfig as { clientId: string; clientSecret?: string; scopes?: string[] } | undefined;
+
     const updates: Partial<typeof mcpServers.$inferInsert> = { updatedAt: new Date() };
     if (name !== undefined) updates.name = name;
     if (transport !== undefined) updates.transport = transport;
@@ -117,6 +162,7 @@ export function makeMcpServersRouter(db: Db): Router {
     if (headers !== undefined) updates.headers = headers;
     if (env !== undefined) updates.env = env;
     if (enabled !== undefined) updates.enabled = enabled;
+    if (oauthConfigBody !== undefined) updates.oauthConfig = oauthConfigBody;
 
     const [row] = await db.update(mcpServers).set(updates).where(eq(mcpServers.id, req.params.id)).returning();
     if (!row) { res.status(404).json({ error: "Not found" }); return; }
@@ -154,6 +200,71 @@ export function makeMcpServersRouter(db: Db): Router {
     } finally {
       await pool.disconnectAll().catch((e) => console.error("[mcp-servers] disconnectAll error:", e));
     }
+  });
+
+  // POST /api/mcp-servers/:id/oauth/connect — initiate OAuth flow
+  router.post("/mcp-servers/:id/oauth/connect", async (req, res) => {
+    const row = await db.query.mcpServers.findFirst({
+      where: eq(mcpServers.id, req.params.id),
+      columns: { id: true, url: true, oauthConfig: true },
+    });
+
+    if (!row) { res.status(404).json({ error: "Not found" }); return; }
+    if (!row.oauthConfig) { res.status(400).json({ error: "Server has no OAuth configuration" }); return; }
+    if (!row.url) { res.status(400).json({ error: "Server has no URL configured" }); return; }
+
+    const redirectUri =
+      process.env.OAUTH_REDIRECT_URI ??
+      `http://localhost:${process.env.PORT || 3009}/api/oauth/callback`;
+
+    try {
+      const result = await initiateOAuthFlow(db, req.params.id, redirectUri);
+      res.json(result);
+    } catch (err) {
+      console.error(`[mcp-servers] OAuth connect failed for "${row.id}":`, err);
+      res.status(502).json({ error: String(err) });
+    }
+  });
+
+  // DELETE /api/mcp-servers/:id/oauth/disconnect — remove OAuth connection
+  router.delete("/mcp-servers/:id/oauth/disconnect", async (req, res) => {
+    const row = await db.query.mcpServers.findFirst({
+      where: eq(mcpServers.id, req.params.id),
+      columns: { id: true },
+    });
+
+    if (!row) { res.status(404).json({ error: "Not found" }); return; }
+
+    await disconnectOAuth(db, req.params.id);
+    res.status(204).end();
+  });
+
+  // GET /api/mcp-servers/:id/oauth/status — check OAuth connection status
+  router.get("/mcp-servers/:id/oauth/status", async (req, res) => {
+    const row = await db.query.mcpServers.findFirst({
+      where: eq(mcpServers.id, req.params.id),
+      columns: { id: true },
+    });
+
+    if (!row) { res.status(404).json({ error: "Not found" }); return; }
+
+    const connection = await db.query.oauthConnections.findFirst({
+      where: eq(oauthConnections.mcpServerId, req.params.id),
+    });
+
+    if (!connection || !connection.status || connection.status !== "active") {
+      res.json({ status: "disconnected" });
+      return;
+    }
+
+    res.json({
+      status: connection.status,
+      connectedAt: connection.connectedAt.toISOString(),
+      lastRefreshedAt: connection.lastRefreshedAt?.toISOString() ?? null,
+      expiresAt: connection.expiresAt?.toISOString() ?? null,
+      scope: connection.scope ?? null,
+      tokenType: connection.tokenType,
+    });
   });
 
   // GET /api/mcp-servers/:id/tools — list available tools (live)

--- a/server/src/routes/oauth.ts
+++ b/server/src/routes/oauth.ts
@@ -1,0 +1,38 @@
+/**
+ * OAuth callback route — handles the browser redirect after the user
+ * authorizes with an external OAuth provider.
+ */
+
+import { Router } from "express";
+import type { Db } from "@pawn/db";
+import { handleOAuthCallback } from "../services/oauth-flow.js";
+
+export function createOAuthRouter(db: Db): Router {
+  const router = Router();
+
+  // GET /oauth/callback — browser redirect from the authorization server
+  router.get("/oauth/callback", async (req, res) => {
+    const code = req.query.code as string | undefined;
+    const state = req.query.state as string | undefined;
+
+    if (!code || !state) {
+      res.redirect("/?oauth=error&message=" + encodeURIComponent("Missing parameters"));
+      return;
+    }
+
+    // Build redirect URI so the provider can match it during token exchange
+    const redirectUri =
+      process.env.OAUTH_REDIRECT_URI ??
+      `http://localhost:${process.env.PORT || 3009}/api/oauth/callback`;
+
+    const result = await handleOAuthCallback(db, state, code, redirectUri);
+
+    if (result.success) {
+      res.redirect(`/?oauth=success&server=${result.mcpServerId}`);
+    } else {
+      res.redirect("/?oauth=error&message=" + encodeURIComponent(result.error ?? "Unknown error"));
+    }
+  });
+
+  return router;
+}

--- a/server/src/services/__tests__/oauth-crypto.test.ts
+++ b/server/src/services/__tests__/oauth-crypto.test.ts
@@ -1,0 +1,163 @@
+import { describe, it, expect, beforeAll, beforeEach, afterEach } from "vitest";
+import { randomBytes } from "node:crypto";
+import { mkdtempSync, writeFileSync, readFileSync, existsSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import {
+  encrypt,
+  decrypt,
+  ensureEncryptionKey,
+  _setKeyForTesting,
+} from "../oauth-crypto.js";
+
+// ── Helpers ──────────────────────────────────────────────────────────────────
+
+/** Generate a fresh 32-byte key and install it via the test helper. */
+function installFreshKey(): Buffer {
+  const key = randomBytes(32);
+  _setKeyForTesting(key);
+  return key;
+}
+
+function makeTmpDir(): string {
+  return mkdtempSync(join(tmpdir(), "oauth-crypto-test-"));
+}
+
+// ── Tests ────────────────────────────────────────────────────────────────────
+
+describe("oauth-crypto", () => {
+  // Install a fresh key before each test so tests are isolated.
+  beforeEach(() => {
+    installFreshKey();
+  });
+
+  // ── encrypt / decrypt round-trip ─────────────────────────────────────────
+
+  describe("encrypt + decrypt round-trip", () => {
+    it("returns the original plaintext", () => {
+      const token = "eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.test-payload.signature";
+      const encrypted = encrypt(token);
+      expect(decrypt(encrypted)).toBe(token);
+    });
+
+    it("produces three colon-separated base64url parts", () => {
+      const encrypted = encrypt("hello");
+      const parts = encrypted.split(":");
+      expect(parts).toHaveLength(3);
+      // Each part should be valid base64url (no +, /, or =)
+      for (const part of parts) {
+        expect(part).toMatch(/^[A-Za-z0-9_-]+$/);
+      }
+    });
+
+    it("produces different ciphertexts for the same plaintext (unique IV)", () => {
+      const plaintext = "same-token-value";
+      const a = encrypt(plaintext);
+      const b = encrypt(plaintext);
+      expect(a).not.toBe(b);
+      // But both decrypt to the same value
+      expect(decrypt(a)).toBe(plaintext);
+      expect(decrypt(b)).toBe(plaintext);
+    });
+
+    it("handles empty string", () => {
+      const encrypted = encrypt("");
+      expect(decrypt(encrypted)).toBe("");
+    });
+  });
+
+  // ── Error paths ──────────────────────────────────────────────────────────
+
+  describe("decrypt error paths", () => {
+    it("throws when decrypting with wrong key", () => {
+      const encrypted = encrypt("secret-token");
+      // Swap to a different key
+      installFreshKey();
+      expect(() => decrypt(encrypted)).toThrow();
+    });
+
+    it("throws on corrupted ciphertext", () => {
+      const encrypted = encrypt("secret-token");
+      const parts = encrypted.split(":");
+      // Corrupt the ciphertext portion
+      parts[1] = "AAAAAAAAAAAAAAAA";
+      const corrupted = parts.join(":");
+      expect(() => decrypt(corrupted)).toThrow();
+    });
+
+    it("throws on malformed format (missing parts)", () => {
+      expect(() => decrypt("onlyonepart")).toThrow(/expected 3 colon-separated parts/);
+      expect(() => decrypt("two:parts")).toThrow(/expected 3 colon-separated parts/);
+      expect(() => decrypt("a:b:c:d")).toThrow(/expected 3 colon-separated parts/);
+    });
+  });
+
+  // ── ensureEncryptionKey ──────────────────────────────────────────────────
+
+  describe("ensureEncryptionKey", () => {
+    const savedEnv = process.env.OAUTH_ENCRYPTION_KEY;
+
+    afterEach(() => {
+      // Restore env
+      if (savedEnv === undefined) {
+        delete process.env.OAUTH_ENCRYPTION_KEY;
+      } else {
+        process.env.OAUTH_ENCRYPTION_KEY = savedEnv;
+      }
+    });
+
+    it("uses OAUTH_ENCRYPTION_KEY env var when set", () => {
+      const key = randomBytes(32);
+      process.env.OAUTH_ENCRYPTION_KEY = key.toString("hex");
+      const source = ensureEncryptionKey(makeTmpDir());
+      expect(source).toBe("env:OAUTH_ENCRYPTION_KEY");
+
+      // Verify encryption works with this key
+      const encrypted = encrypt("via-env");
+      expect(decrypt(encrypted)).toBe("via-env");
+    });
+
+    it("throws when env var key has wrong length", () => {
+      process.env.OAUTH_ENCRYPTION_KEY = "aabbcc"; // only 3 bytes
+      expect(() => ensureEncryptionKey(makeTmpDir())).toThrow(/must be a hex-encoded 32-byte key/);
+    });
+
+    it("generates a new key file when none exists", () => {
+      delete process.env.OAUTH_ENCRYPTION_KEY;
+      const dir = makeTmpDir();
+      const source = ensureEncryptionKey(dir);
+      expect(source).toBe(`file:${join(dir, "oauth-encryption.key")}`);
+
+      // Key file should exist and contain 64 hex chars
+      const keyFile = join(dir, "oauth-encryption.key");
+      expect(existsSync(keyFile)).toBe(true);
+      const hex = readFileSync(keyFile, "utf-8").trim();
+      expect(hex).toMatch(/^[0-9a-f]{64}$/);
+
+      // Encryption should work
+      const encrypted = encrypt("generated-key");
+      expect(decrypt(encrypted)).toBe("generated-key");
+    });
+
+    it("reads an existing key file", () => {
+      delete process.env.OAUTH_ENCRYPTION_KEY;
+      const dir = makeTmpDir();
+      const key = randomBytes(32);
+      writeFileSync(join(dir, "oauth-encryption.key"), key.toString("hex"));
+
+      const source = ensureEncryptionKey(dir);
+      expect(source).toBe(`file:${join(dir, "oauth-encryption.key")}`);
+
+      const encrypted = encrypt("from-file");
+      expect(decrypt(encrypted)).toBe("from-file");
+    });
+
+    it("throws when key file is malformed (wrong length)", () => {
+      delete process.env.OAUTH_ENCRYPTION_KEY;
+      const dir = makeTmpDir();
+      writeFileSync(join(dir, "oauth-encryption.key"), "deadbeef"); // only 4 bytes
+
+      expect(() => ensureEncryptionKey(dir)).toThrow(/Key file is malformed/);
+    });
+  });
+});

--- a/server/src/services/execution-engine.ts
+++ b/server/src/services/execution-engine.ts
@@ -172,6 +172,7 @@ export class ExecutionEngine {
     const logger = new RunLogger(runId);
     const runStartMs = Date.now();
     const mcpPool = new McpClientPool();
+    mcpPool.setDb(this.db);
 
     const run = await this.db.query.pipelineRuns.findFirst({
       where: eq(pipelineRuns.id, runId),

--- a/server/src/services/mcp-client.ts
+++ b/server/src/services/mcp-client.ts
@@ -7,6 +7,11 @@ import { Client } from "@modelcontextprotocol/sdk/client/index.js";
 import { StdioClientTransport } from "@modelcontextprotocol/sdk/client/stdio.js";
 import { SSEClientTransport } from "@modelcontextprotocol/sdk/client/sse.js";
 import { StreamableHTTPClientTransport } from "@modelcontextprotocol/sdk/client/streamableHttp.js";
+import type { OAuthClientProvider } from "@modelcontextprotocol/sdk/client/auth.js";
+import type { Db } from "@pawn/db";
+import { oauthConnections } from "@pawn/db";
+import { eq } from "drizzle-orm";
+import { PawnOAuthClientProvider } from "./oauth-provider.js";
 
 export interface McpServerConfig {
   id: string;
@@ -17,6 +22,7 @@ export interface McpServerConfig {
   url?: string;
   headers?: Record<string, string>;
   env?: Record<string, string>;
+  oauthConfig?: { clientId: string; clientSecret?: string; scopes?: string[] };
 }
 
 export interface McpToolInfo {
@@ -58,14 +64,30 @@ export function resolveEnvRefs(
 
 export class McpClientPool {
   private entries = new Map<string, PoolEntry>();
+  private db?: Db;
+
+  setDb(db: Db): void {
+    this.db = db;
+  }
 
   async connect(config: McpServerConfig): Promise<McpToolInfo[]> {
     if (this.entries.has(config.name)) {
       return this.entries.get(config.name)!.tools;
     }
 
+    let authProvider: OAuthClientProvider | undefined;
+    if (this.db && config.oauthConfig && (config.transport === "sse" || config.transport === "streamable-http")) {
+      const connection = await this.db.query.oauthConnections.findFirst({
+        where: eq(oauthConnections.mcpServerId, config.id),
+      });
+      if (connection && connection.status === "active") {
+        const redirectUri = process.env.OAUTH_REDIRECT_URI || `http://localhost:${process.env.PORT || 3009}/api/oauth/callback`;
+        authProvider = new PawnOAuthClientProvider(this.db, config.id, redirectUri);
+      }
+    }
+
     const client = new Client({ name: "pawn", version: "1.0.0" });
-    const transport = buildTransport(config);
+    const transport = buildTransport(config, authProvider);
 
     await Promise.race([
       client.connect(transport),
@@ -117,7 +139,7 @@ export class McpClientPool {
   }
 }
 
-function buildTransport(config: McpServerConfig) {
+function buildTransport(config: McpServerConfig, authProvider?: OAuthClientProvider) {
   switch (config.transport) {
     case "stdio": {
       if (!config.command) throw new Error(`MCP stdio server ${config.name} missing command`);
@@ -130,12 +152,14 @@ function buildTransport(config: McpServerConfig) {
     case "sse": {
       if (!config.url) throw new Error(`MCP SSE server ${config.name} missing url`);
       return new SSEClientTransport(new URL(config.url), {
+        authProvider,
         requestInit: config.headers ? { headers: config.headers } : undefined,
       });
     }
     case "streamable-http": {
       if (!config.url) throw new Error(`MCP streamable-http server ${config.name} missing url`);
       return new StreamableHTTPClientTransport(new URL(config.url), {
+        authProvider,
         requestInit: config.headers ? { headers: config.headers } : undefined,
       });
     }

--- a/server/src/services/oauth-crypto.ts
+++ b/server/src/services/oauth-crypto.ts
@@ -1,0 +1,141 @@
+/**
+ * AES-256-GCM encryption service for OAuth token storage at rest.
+ *
+ * Tokens are encrypted with a 32-byte key that is either:
+ *   1. Provided via OAUTH_ENCRYPTION_KEY env var (hex-encoded), or
+ *   2. Read from / generated into DATA_DIR/oauth-encryption.key
+ */
+
+import { createCipheriv, createDecipheriv, randomBytes } from "node:crypto";
+import { existsSync, readFileSync, writeFileSync, mkdirSync } from "node:fs";
+import { join, dirname } from "node:path";
+
+const ALGORITHM = "aes-256-gcm";
+const IV_LENGTH = 12; // 96-bit IV recommended for GCM
+const KEY_LENGTH = 32; // 256 bits
+const AUTH_TAG_LENGTH = 16; // 128-bit auth tag
+
+// Module-level key, initialised by ensureEncryptionKey()
+let encryptionKey: Buffer | null = null;
+
+// ── Helpers ──────────────────────────────────────────────────────────────────
+
+function toBase64Url(buf: Buffer): string {
+  return buf.toString("base64url");
+}
+
+function fromBase64Url(str: string): Buffer {
+  return Buffer.from(str, "base64url");
+}
+
+function getKey(): Buffer {
+  if (!encryptionKey) {
+    throw new Error(
+      "[oauth-crypto] Encryption key not initialised. Call ensureEncryptionKey() first.",
+    );
+  }
+  return encryptionKey;
+}
+
+// ── Public API ───────────────────────────────────────────────────────────────
+
+/**
+ * Encrypt a plaintext string using AES-256-GCM.
+ * Returns `iv:ciphertext:authTag` (all base64url-encoded, colon-separated).
+ */
+export function encrypt(plaintext: string): string {
+  const key = getKey();
+  const iv = randomBytes(IV_LENGTH);
+  const cipher = createCipheriv(ALGORITHM, key, iv, { authTagLength: AUTH_TAG_LENGTH });
+
+  const encrypted = Buffer.concat([cipher.update(plaintext, "utf8"), cipher.final()]);
+  const authTag = cipher.getAuthTag();
+
+  return `${toBase64Url(iv)}:${toBase64Url(encrypted)}:${toBase64Url(authTag)}`;
+}
+
+/**
+ * Decrypt a string previously produced by `encrypt()`.
+ * Expects `iv:ciphertext:authTag` format (base64url-encoded, colon-separated).
+ */
+export function decrypt(encrypted: string): string {
+  const key = getKey();
+  const parts = encrypted.split(":");
+
+  if (parts.length !== 3) {
+    throw new Error(
+      "[oauth-crypto] Malformed encrypted string: expected 3 colon-separated parts.",
+    );
+  }
+
+  const [ivB64, ciphertextB64, authTagB64] = parts;
+  const iv = fromBase64Url(ivB64);
+  const ciphertext = fromBase64Url(ciphertextB64);
+  const authTag = fromBase64Url(authTagB64);
+
+  const decipher = createDecipheriv(ALGORITHM, key, iv, { authTagLength: AUTH_TAG_LENGTH });
+  decipher.setAuthTag(authTag);
+
+  const decrypted = Buffer.concat([decipher.update(ciphertext), decipher.final()]);
+  return decrypted.toString("utf8");
+}
+
+/**
+ * Initialise the module-level encryption key.
+ *
+ * Resolution order:
+ *   1. `OAUTH_ENCRYPTION_KEY` env var (hex-encoded 32-byte key)
+ *   2. `<dataDir>/oauth-encryption.key` file (hex-encoded)
+ *   3. Generate a new random key and persist it to the file above
+ *
+ * Returns a human-readable source description for logging, e.g.
+ *   `"env:OAUTH_ENCRYPTION_KEY"` or `"file:/path/to/oauth-encryption.key"`
+ */
+export function ensureEncryptionKey(dataDir: string): string {
+  // 1. Environment variable
+  const envKey = process.env.OAUTH_ENCRYPTION_KEY;
+  if (envKey) {
+    const buf = Buffer.from(envKey, "hex");
+    if (buf.length !== KEY_LENGTH) {
+      throw new Error(
+        `[oauth-crypto] OAUTH_ENCRYPTION_KEY must be a hex-encoded ${KEY_LENGTH}-byte key ` +
+          `(${KEY_LENGTH * 2} hex chars). Got ${buf.length} bytes.`,
+      );
+    }
+    encryptionKey = buf;
+    return "env:OAUTH_ENCRYPTION_KEY";
+  }
+
+  // 2. Key file
+  const keyFilePath = join(dataDir, "oauth-encryption.key");
+
+  if (existsSync(keyFilePath)) {
+    const hex = readFileSync(keyFilePath, "utf-8").trim();
+    const buf = Buffer.from(hex, "hex");
+    if (buf.length !== KEY_LENGTH) {
+      throw new Error(
+        `[oauth-crypto] Key file is malformed: expected ${KEY_LENGTH}-byte key ` +
+          `(${KEY_LENGTH * 2} hex chars) but got ${buf.length} bytes. ` +
+          `Fix or remove: ${keyFilePath}`,
+      );
+    }
+    encryptionKey = buf;
+    return `file:${keyFilePath}`;
+  }
+
+  // 3. Generate new key
+  const newKey = randomBytes(KEY_LENGTH);
+  mkdirSync(dirname(keyFilePath), { recursive: true });
+  writeFileSync(keyFilePath, newKey.toString("hex"), { mode: 0o600 });
+  encryptionKey = newKey;
+  return `file:${keyFilePath}`;
+}
+
+// ── Test-only helpers ────────────────────────────────────────────────────────
+
+/**
+ * Replace the module-level encryption key. **Test use only.**
+ */
+export function _setKeyForTesting(key: Buffer): void {
+  encryptionKey = key;
+}

--- a/server/src/services/oauth-flow.ts
+++ b/server/src/services/oauth-flow.ts
@@ -1,0 +1,151 @@
+/**
+ * OAuth Flow Service — orchestrates the OAuth authorization code flow
+ * using the MCP SDK's auth() orchestrator and our PawnOAuthClientProvider.
+ */
+
+import { eq } from "drizzle-orm";
+import { auth } from "@modelcontextprotocol/sdk/client/auth.js";
+import type { Db } from "@pawn/db";
+import { mcpServers, oauthConnections, oauthPendingFlows } from "@pawn/db";
+import { PawnOAuthClientProvider } from "./oauth-provider.js";
+
+// ---------------------------------------------------------------------------
+// initiateOAuthFlow
+// ---------------------------------------------------------------------------
+
+/**
+ * Kicks off an OAuth authorization-code flow for the given MCP server.
+ *
+ * Creates a PawnOAuthClientProvider and delegates to the SDK's `auth()`
+ * orchestrator, which will:
+ *   1. Discover the authorization server
+ *   2. Generate a PKCE code verifier (saved via provider.saveCodeVerifier)
+ *   3. Build the authorization URL and call provider.redirectToAuthorization
+ *
+ * Because we run server-side (no browser redirect), the provider captures the
+ * authorization URL instead of redirecting. We return it to the caller so the
+ * frontend can open it.
+ */
+export async function initiateOAuthFlow(
+  db: Db,
+  mcpServerId: string,
+  redirectUri: string,
+): Promise<{ authUrl: string; state: string }> {
+  const server = await db.query.mcpServers.findFirst({
+    where: eq(mcpServers.id, mcpServerId),
+    columns: { url: true },
+  });
+
+  if (!server?.url) {
+    throw new Error(`MCP server ${mcpServerId} has no URL configured`);
+  }
+
+  const provider = new PawnOAuthClientProvider(db, mcpServerId, redirectUri);
+
+  const result = await auth(provider, { serverUrl: server.url });
+
+  if (result !== "REDIRECT") {
+    // If already authorized we still return — the caller can decide what to do.
+    // But there won't be an authorizationUrl, so treat as an error for the
+    // "initiate" use-case.
+    throw new Error("OAuth flow did not produce a redirect — server may already be authorized");
+  }
+
+  const authorizationUrl = provider.authorizationUrl;
+  if (!authorizationUrl) {
+    throw new Error("OAuth auth() returned REDIRECT but no authorization URL was captured");
+  }
+
+  // Retrieve the state that the provider persisted during saveCodeVerifier / state()
+  const pendingFlow = await db.query.oauthPendingFlows.findFirst({
+    where: eq(oauthPendingFlows.mcpServerId, mcpServerId),
+    columns: { state: true },
+  });
+
+  if (!pendingFlow) {
+    throw new Error("No pending OAuth flow found after auth() — state was not persisted");
+  }
+
+  return {
+    authUrl: authorizationUrl.toString(),
+    state: pendingFlow.state,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// handleOAuthCallback
+// ---------------------------------------------------------------------------
+
+/**
+ * Handles the OAuth callback after the user has authorized.
+ *
+ * Looks up the pending flow by `state`, validates expiry, then calls the SDK's
+ * `auth()` with the authorization code so it can exchange it for tokens.
+ */
+export async function handleOAuthCallback(
+  db: Db,
+  state: string,
+  code: string,
+  redirectUri: string,
+): Promise<{ success: boolean; mcpServerId: string; error?: string }> {
+  // 1. Look up the pending flow by state
+  const pendingFlow = await db.query.oauthPendingFlows.findFirst({
+    where: eq(oauthPendingFlows.state, state),
+  });
+
+  if (!pendingFlow) {
+    return { success: false, mcpServerId: "", error: "Unknown or expired OAuth state" };
+  }
+
+  const { mcpServerId } = pendingFlow;
+
+  try {
+    // 2. Validate expiry
+    if (new Date(pendingFlow.expiresAt) < new Date()) {
+      await db.delete(oauthPendingFlows).where(eq(oauthPendingFlows.state, state));
+      return { success: false, mcpServerId, error: "OAuth flow has expired — please try again" };
+    }
+
+    // 3. Get the MCP server URL
+    const server = await db.query.mcpServers.findFirst({
+      where: eq(mcpServers.id, mcpServerId),
+      columns: { url: true },
+    });
+
+    if (!server?.url) {
+      return { success: false, mcpServerId, error: "MCP server not found or has no URL" };
+    }
+
+    // 4. Create provider and exchange the code for tokens via auth()
+    const provider = new PawnOAuthClientProvider(db, mcpServerId, redirectUri);
+
+    await auth(provider, {
+      serverUrl: server.url,
+      authorizationCode: code,
+    });
+
+    // 5. Clean up the pending flow
+    await db.delete(oauthPendingFlows).where(eq(oauthPendingFlows.state, state));
+
+    return { success: true, mcpServerId };
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    console.error(`[oauth-flow] Callback failed for server ${mcpServerId}:`, message);
+    return { success: false, mcpServerId, error: message };
+  }
+}
+
+// ---------------------------------------------------------------------------
+// disconnectOAuth
+// ---------------------------------------------------------------------------
+
+/**
+ * Removes all OAuth data for a given MCP server (connection + pending flows).
+ */
+export async function disconnectOAuth(
+  db: Db,
+  mcpServerId: string,
+): Promise<void> {
+  await db.delete(oauthConnections).where(eq(oauthConnections.mcpServerId, mcpServerId));
+  await db.delete(oauthPendingFlows).where(eq(oauthPendingFlows.mcpServerId, mcpServerId));
+}

--- a/server/src/services/oauth-provider.ts
+++ b/server/src/services/oauth-provider.ts
@@ -1,0 +1,369 @@
+/**
+ * OAuthClientProvider implementation backed by database storage and encryption.
+ *
+ * Implements the MCP SDK's OAuthClientProvider interface so that the Pawn server
+ * can act as an OAuth client on behalf of the user when connecting to
+ * OAuth-protected MCP servers.
+ */
+
+import { randomBytes } from "node:crypto";
+import { eq } from "drizzle-orm";
+import type { OAuthClientProvider } from "@modelcontextprotocol/sdk/client/auth.js";
+import type { OAuthDiscoveryState } from "@modelcontextprotocol/sdk/client/auth.js";
+import type {
+  OAuthClientMetadata,
+  OAuthClientInformationMixed,
+  OAuthTokens,
+} from "@modelcontextprotocol/sdk/shared/auth.js";
+import type { Db } from "@pawn/db";
+import { mcpServers, oauthConnections, oauthPendingFlows } from "@pawn/db";
+import { encrypt, decrypt } from "./oauth-crypto.js";
+
+// ---------------------------------------------------------------------------
+// Provider
+// ---------------------------------------------------------------------------
+
+export class PawnOAuthClientProvider implements OAuthClientProvider {
+  private db: Db;
+  private mcpServerId: string;
+  private redirectUri: string;
+
+  /** Captured authorization URL (server-mediated flow — we don't redirect). */
+  private _authorizationUrl: URL | undefined;
+
+  /** Cached client secret presence for clientMetadata getter. */
+  private _hasClientSecret: boolean | undefined;
+
+  constructor(db: Db, mcpServerId: string, redirectUri: string) {
+    this.db = db;
+    this.mcpServerId = mcpServerId;
+    this.redirectUri = redirectUri;
+  }
+
+  // -- 1. redirectUrl -------------------------------------------------------
+
+  get redirectUrl(): string {
+    return this.redirectUri;
+  }
+
+  // -- 2. clientMetadata ----------------------------------------------------
+
+  get clientMetadata(): OAuthClientMetadata {
+    return {
+      redirect_uris: [this.redirectUri],
+      client_name: "Pawn",
+      grant_types: ["authorization_code"],
+      response_types: ["code"],
+      token_endpoint_auth_method:
+        this._hasClientSecret === true ? "client_secret_post" : "none",
+    };
+  }
+
+  // -- 3. clientInformation -------------------------------------------------
+
+  async clientInformation(): Promise<OAuthClientInformationMixed | undefined> {
+    const row = await this.db.query.mcpServers.findFirst({
+      where: eq(mcpServers.id, this.mcpServerId),
+      columns: { oauthConfig: true },
+    });
+
+    if (!row?.oauthConfig) return undefined;
+
+    const config = row.oauthConfig as {
+      clientId: string;
+      clientSecret?: string;
+    };
+
+    // Cache for clientMetadata getter
+    this._hasClientSecret = !!config.clientSecret;
+
+    const info: OAuthClientInformationMixed = {
+      client_id: config.clientId,
+      ...(config.clientSecret
+        ? { client_secret: config.clientSecret }
+        : undefined),
+    };
+
+    return info;
+  }
+
+  // -- 4. saveClientInformation ---------------------------------------------
+
+  async saveClientInformation(
+    info: OAuthClientInformationMixed,
+  ): Promise<void> {
+    await this.db
+      .insert(oauthConnections)
+      .values({
+        mcpServerId: this.mcpServerId,
+        accessToken: "", // placeholder — no token yet
+        clientRegistration: info,
+      })
+      .onConflictDoUpdate({
+        target: oauthConnections.mcpServerId,
+        set: { clientRegistration: info },
+      });
+  }
+
+  // -- 5. tokens ------------------------------------------------------------
+
+  async tokens(): Promise<OAuthTokens | undefined> {
+    const row = await this.db.query.oauthConnections.findFirst({
+      where: eq(oauthConnections.mcpServerId, this.mcpServerId),
+    });
+
+    if (!row || row.status !== "active" || !row.accessToken) return undefined;
+
+    let accessToken: string;
+    try {
+      accessToken = decrypt(row.accessToken);
+    } catch {
+      // If the stored token is empty or cannot be decrypted, treat as missing
+      return undefined;
+    }
+
+    let refreshToken: string | undefined;
+    if (row.refreshToken) {
+      try {
+        refreshToken = decrypt(row.refreshToken);
+      } catch {
+        refreshToken = undefined;
+      }
+    }
+
+    let expiresIn: number | undefined;
+    if (row.expiresAt) {
+      const diffMs = new Date(row.expiresAt).getTime() - Date.now();
+      expiresIn = Math.max(0, Math.floor(diffMs / 1000));
+    }
+
+    return {
+      access_token: accessToken,
+      token_type: row.tokenType ?? "Bearer",
+      ...(refreshToken ? { refresh_token: refreshToken } : undefined),
+      ...(expiresIn !== undefined ? { expires_in: expiresIn } : undefined),
+    };
+  }
+
+  // -- 6. saveTokens --------------------------------------------------------
+
+  async saveTokens(tokens: OAuthTokens): Promise<void> {
+    const encryptedAccessToken = encrypt(tokens.access_token);
+    const encryptedRefreshToken = tokens.refresh_token
+      ? encrypt(tokens.refresh_token)
+      : null;
+
+    const expiresAt = tokens.expires_in
+      ? new Date(Date.now() + tokens.expires_in * 1000)
+      : null;
+
+    await this.db
+      .insert(oauthConnections)
+      .values({
+        mcpServerId: this.mcpServerId,
+        accessToken: encryptedAccessToken,
+        refreshToken: encryptedRefreshToken,
+        tokenType: tokens.token_type ?? "Bearer",
+        expiresAt,
+        status: "active",
+        connectedAt: new Date(),
+        errorMessage: null,
+      })
+      .onConflictDoUpdate({
+        target: oauthConnections.mcpServerId,
+        set: {
+          accessToken: encryptedAccessToken,
+          refreshToken: encryptedRefreshToken,
+          tokenType: tokens.token_type ?? "Bearer",
+          expiresAt,
+          status: "active",
+          connectedAt: new Date(),
+          lastRefreshedAt: new Date(),
+          errorMessage: null,
+        },
+      });
+  }
+
+  // -- 7. redirectToAuthorization -------------------------------------------
+
+  async redirectToAuthorization(authorizationUrl: URL): Promise<void> {
+    this._authorizationUrl = authorizationUrl;
+  }
+
+  /** Retrieve the captured authorization URL (server-mediated flow). */
+  get authorizationUrl(): URL | undefined {
+    return this._authorizationUrl;
+  }
+
+  // -- 8. saveCodeVerifier --------------------------------------------------
+
+  async saveCodeVerifier(codeVerifier: string): Promise<void> {
+    const state = randomBytes(32).toString("hex");
+
+    // Delete any existing pending flow for this server, then insert
+    await this.db
+      .delete(oauthPendingFlows)
+      .where(eq(oauthPendingFlows.mcpServerId, this.mcpServerId));
+
+    await this.db.insert(oauthPendingFlows).values({
+      mcpServerId: this.mcpServerId,
+      state,
+      codeVerifier,
+      redirectUri: this.redirectUri,
+    });
+  }
+
+  // -- 9. codeVerifier ------------------------------------------------------
+
+  async codeVerifier(): Promise<string> {
+    const row = await this.db.query.oauthPendingFlows.findFirst({
+      where: eq(oauthPendingFlows.mcpServerId, this.mcpServerId),
+      columns: { codeVerifier: true },
+    });
+
+    if (!row) {
+      throw new Error(
+        `[oauth-provider] No pending flow found for server ${this.mcpServerId}`,
+      );
+    }
+
+    return row.codeVerifier;
+  }
+
+  // -- 10. state ------------------------------------------------------------
+
+  async state(): Promise<string> {
+    const row = await this.db.query.oauthPendingFlows.findFirst({
+      where: eq(oauthPendingFlows.mcpServerId, this.mcpServerId),
+      columns: { state: true },
+    });
+
+    if (row) return row.state;
+
+    // No pending flow — generate and store a new state
+    const newState = randomBytes(32).toString("hex");
+    const codeVerifier = randomBytes(32).toString("base64url");
+
+    await this.db.insert(oauthPendingFlows).values({
+      mcpServerId: this.mcpServerId,
+      state: newState,
+      codeVerifier,
+      redirectUri: this.redirectUri,
+    });
+
+    return newState;
+  }
+
+  // -- 11. invalidateCredentials --------------------------------------------
+
+  async invalidateCredentials(
+    scope: "all" | "client" | "tokens" | "verifier" | "discovery",
+  ): Promise<void> {
+    switch (scope) {
+      case "all":
+        await this.db
+          .delete(oauthConnections)
+          .where(eq(oauthConnections.mcpServerId, this.mcpServerId));
+        await this.db
+          .delete(oauthPendingFlows)
+          .where(eq(oauthPendingFlows.mcpServerId, this.mcpServerId));
+        break;
+
+      case "tokens":
+        await this.db
+          .update(oauthConnections)
+          .set({ status: "revoked" })
+          .where(eq(oauthConnections.mcpServerId, this.mcpServerId));
+        break;
+
+      case "verifier":
+        await this.db
+          .delete(oauthPendingFlows)
+          .where(eq(oauthPendingFlows.mcpServerId, this.mcpServerId));
+        break;
+
+      case "client":
+        await this.db
+          .update(oauthConnections)
+          .set({ clientRegistration: null })
+          .where(eq(oauthConnections.mcpServerId, this.mcpServerId));
+        break;
+
+      case "discovery":
+        await this.db
+          .update(oauthConnections)
+          .set({ discoveryState: null })
+          .where(eq(oauthConnections.mcpServerId, this.mcpServerId));
+        break;
+    }
+  }
+
+  // -- 12. saveDiscoveryState -----------------------------------------------
+
+  async saveDiscoveryState(state: OAuthDiscoveryState): Promise<void> {
+    await this.db
+      .insert(oauthConnections)
+      .values({
+        mcpServerId: this.mcpServerId,
+        accessToken: "", // placeholder
+        discoveryState: state,
+      })
+      .onConflictDoUpdate({
+        target: oauthConnections.mcpServerId,
+        set: { discoveryState: state },
+      });
+  }
+
+  // -- 13. discoveryState ---------------------------------------------------
+
+  async discoveryState(): Promise<OAuthDiscoveryState | undefined> {
+    const row = await this.db.query.oauthConnections.findFirst({
+      where: eq(oauthConnections.mcpServerId, this.mcpServerId),
+      columns: { discoveryState: true },
+    });
+
+    if (!row?.discoveryState) return undefined;
+
+    return row.discoveryState as OAuthDiscoveryState;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Standalone helper
+// ---------------------------------------------------------------------------
+
+/**
+ * Quick check of OAuth connection status without creating a full provider.
+ */
+export async function getOAuthConnectionStatus(
+  db: Db,
+  mcpServerId: string,
+): Promise<
+  | { connected: false }
+  | {
+      connected: true;
+      status: string;
+      connectedAt: Date;
+      expiresAt: Date | null;
+    }
+> {
+  const row = await db.query.oauthConnections.findFirst({
+    where: eq(oauthConnections.mcpServerId, mcpServerId),
+    columns: {
+      status: true,
+      connectedAt: true,
+      expiresAt: true,
+    },
+  });
+
+  if (!row || row.status !== "active") {
+    return { connected: false };
+  }
+
+  return {
+    connected: true,
+    status: row.status,
+    connectedAt: row.connectedAt,
+    expiresAt: row.expiresAt,
+  };
+}

--- a/server/src/services/oauth-refresh.ts
+++ b/server/src/services/oauth-refresh.ts
@@ -1,0 +1,193 @@
+/**
+ * Background polling service that refreshes OAuth tokens before they expire.
+ *
+ * Follows the same start/stop pattern as ollama-provider.ts.
+ * Runs every 60 seconds, picking up active connections whose access tokens
+ * will expire within the next 5 minutes and attempting a token refresh.
+ */
+
+import type { Db } from "@pawn/db";
+import { oauthConnections, mcpServers } from "@pawn/db";
+import { eq, and, lte, isNotNull, sql } from "drizzle-orm";
+import {
+  refreshAuthorization,
+  discoverOAuthServerInfo,
+} from "@modelcontextprotocol/sdk/client/auth.js";
+import type {
+  OAuthDiscoveryState,
+} from "@modelcontextprotocol/sdk/client/auth.js";
+import type { OAuthClientInformationMixed } from "@modelcontextprotocol/sdk/shared/auth.js";
+import { encrypt, decrypt } from "./oauth-crypto.js";
+
+// ── Constants ───────────────────────────────────────────────────────────────
+
+const POLL_INTERVAL_MS = 60_000; // 60 seconds
+const EXPIRY_BUFFER_MS = 5 * 60 * 1000; // 5 minutes
+
+// ── Module state ────────────────────────────────────────────────────────────
+
+let pollTimer: ReturnType<typeof setInterval> | null = null;
+
+// ── Public API ──────────────────────────────────────────────────────────────
+
+export function startOAuthRefreshPolling(db: Db): void {
+  if (pollTimer) return;
+
+  console.log("[oauth-refresh] Starting background token refresh polling");
+  pollTimer = setInterval(() => void refreshExpiringTokens(db), POLL_INTERVAL_MS);
+}
+
+export function stopOAuthRefreshPolling(): void {
+  if (pollTimer) {
+    clearInterval(pollTimer);
+    pollTimer = null;
+    console.log("[oauth-refresh] Stopped background token refresh polling");
+  }
+}
+
+// ── Internal ────────────────────────────────────────────────────────────────
+
+async function refreshExpiringTokens(db: Db): Promise<void> {
+  try {
+    const threshold = new Date(Date.now() + EXPIRY_BUFFER_MS);
+
+    // Find active connections expiring within the buffer window that have a refresh token
+    const expiring = await db
+      .select({
+        id: oauthConnections.id,
+        mcpServerId: oauthConnections.mcpServerId,
+        refreshToken: oauthConnections.refreshToken,
+        discoveryState: oauthConnections.discoveryState,
+      })
+      .from(oauthConnections)
+      .where(
+        and(
+          eq(oauthConnections.status, "active"),
+          isNotNull(oauthConnections.expiresAt),
+          lte(oauthConnections.expiresAt, threshold),
+          isNotNull(oauthConnections.refreshToken),
+        ),
+      );
+
+    if (expiring.length === 0) return;
+
+    console.log(
+      `[oauth-refresh] Found ${expiring.length} token(s) expiring soon, attempting refresh`,
+    );
+
+    for (const conn of expiring) {
+      try {
+        await refreshSingleConnection(db, conn);
+      } catch (err) {
+        // Mark the connection as errored so it stops being picked up
+        const message =
+          err instanceof Error ? err.message : String(err);
+        console.error(
+          `[oauth-refresh] Failed to refresh token for connection ${conn.id}: ${message}`,
+        );
+
+        await db
+          .update(oauthConnections)
+          .set({
+            status: "error",
+            errorMessage: `Token refresh failed: ${message}`,
+          })
+          .where(eq(oauthConnections.id, conn.id));
+      }
+    }
+  } catch (err) {
+    // Top-level catch so the interval keeps running
+    console.error(
+      "[oauth-refresh] Unexpected error during refresh cycle:",
+      err,
+    );
+  }
+}
+
+async function refreshSingleConnection(
+  db: Db,
+  conn: {
+    id: string;
+    mcpServerId: string;
+    refreshToken: string | null;
+    discoveryState: unknown;
+  },
+): Promise<void> {
+  if (!conn.refreshToken) return;
+
+  // 1. Get MCP server URL and OAuth config
+  const server = await db.query.mcpServers.findFirst({
+    where: eq(mcpServers.id, conn.mcpServerId),
+    columns: { url: true, oauthConfig: true },
+  });
+
+  if (!server?.url) {
+    throw new Error(`MCP server ${conn.mcpServerId} has no URL`);
+  }
+
+  if (!server.oauthConfig) {
+    throw new Error(`MCP server ${conn.mcpServerId} has no OAuth config`);
+  }
+
+  const oauthConfig = server.oauthConfig as {
+    clientId: string;
+    clientSecret?: string;
+  };
+
+  // 2. Decrypt the refresh token
+  const refreshToken = decrypt(conn.refreshToken);
+
+  // 3. Discover auth server info (use cached discovery state if available)
+  let authorizationServerUrl: string;
+  let metadata;
+
+  const cached = conn.discoveryState as OAuthDiscoveryState | null;
+  if (cached?.authorizationServerUrl && cached?.authorizationServerMetadata) {
+    authorizationServerUrl = cached.authorizationServerUrl;
+    metadata = cached.authorizationServerMetadata;
+  } else {
+    const info = await discoverOAuthServerInfo(server.url);
+    authorizationServerUrl = info.authorizationServerUrl;
+    metadata = info.authorizationServerMetadata;
+  }
+
+  // 4. Build client information
+  const clientInformation: OAuthClientInformationMixed = {
+    client_id: oauthConfig.clientId,
+    ...(oauthConfig.clientSecret
+      ? { client_secret: oauthConfig.clientSecret }
+      : undefined),
+  };
+
+  // 5. Refresh the token
+  const tokens = await refreshAuthorization(authorizationServerUrl, {
+    metadata,
+    clientInformation,
+    refreshToken,
+  });
+
+  // 6. Encrypt and persist
+  const encryptedAccessToken = encrypt(tokens.access_token);
+  const encryptedRefreshToken = tokens.refresh_token
+    ? encrypt(tokens.refresh_token)
+    : conn.refreshToken; // keep the old one if not rotated
+
+  const expiresAt = tokens.expires_in
+    ? new Date(Date.now() + tokens.expires_in * 1000)
+    : null;
+
+  await db
+    .update(oauthConnections)
+    .set({
+      accessToken: encryptedAccessToken,
+      refreshToken: encryptedRefreshToken,
+      expiresAt,
+      lastRefreshedAt: new Date(),
+      errorMessage: null,
+    })
+    .where(eq(oauthConnections.id, conn.id));
+
+  console.log(
+    `[oauth-refresh] Successfully refreshed token for connection ${conn.id}`,
+  );
+}

--- a/ui/src/components/OAuthConnectionCard.tsx
+++ b/ui/src/components/OAuthConnectionCard.tsx
@@ -1,0 +1,216 @@
+import { useState } from "react";
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { ChevronDown, ChevronRight, ShieldCheck, ShieldAlert, ShieldX, Unplug, Loader, KeyRound } from "lucide-react";
+import { api } from "../lib/api.ts";
+import type { ApiMcpServer } from "@pawn/shared";
+
+export default function OAuthConnectionCard({ server }: { server: ApiMcpServer }) {
+  const queryClient = useQueryClient();
+  const [configExpanded, setConfigExpanded] = useState(false);
+  const [clientId, setClientId] = useState("");
+  const [clientSecret, setClientSecret] = useState("");
+  const [scopes, setScopes] = useState("");
+  const [saveError, setSaveError] = useState("");
+
+  const saveConfig = useMutation({
+    mutationFn: () =>
+      api.updateMcpServer(server.id, {
+        oauthConfig: {
+          clientId: clientId.trim(),
+          hasClientSecret: !!clientSecret.trim(),
+          scopes: scopes.trim() ? scopes.split(",").map((s) => s.trim()).filter(Boolean) : undefined,
+        },
+        // Send the secret via a separate field the backend expects
+        ...(clientSecret.trim() ? { oauthClientSecret: clientSecret.trim() } as Record<string, string> : {}),
+      }),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ["mcp-servers"] });
+      setSaveError("");
+    },
+    onError: (e: Error) => setSaveError(e.message),
+  });
+
+  const connect = useMutation({
+    mutationFn: () => api.initiateOAuthConnect(server.id),
+    onSuccess: (data) => {
+      window.open(data.authUrl, "_blank");
+    },
+    onError: (e: Error) => setSaveError(e.message),
+  });
+
+  const disconnect = useMutation({
+    mutationFn: () => api.disconnectOAuth(server.id),
+    onSuccess: () => queryClient.invalidateQueries({ queryKey: ["mcp-servers"] }),
+    onError: (e: Error) => setSaveError(e.message),
+  });
+
+  const conn = server.oauthConnection;
+  const config = server.oauthConfig;
+
+  // ── Connected ──────────────────────────────────────────────────────────────
+  if (conn && conn.status === "active") {
+    const expiresLabel = conn.expiresAt
+      ? formatRelativeTime(conn.expiresAt)
+      : "Never";
+
+    return (
+      <div className="border-t border-pawn-surface-800 bg-pawn-surface-950 px-4 py-3">
+        <div className="flex items-center justify-between">
+          <div className="flex items-center gap-2">
+            <ShieldCheck size={14} className="text-emerald-400" />
+            <span className="text-xs font-medium text-emerald-400">Connected</span>
+            {conn.scope && (
+              <span className="text-xs text-pawn-surface-500 font-mono ml-1">
+                {conn.scope}
+              </span>
+            )}
+          </div>
+          <div className="flex items-center gap-3">
+            <span className="text-xs text-pawn-surface-500">
+              Expires: {expiresLabel}
+            </span>
+            <button
+              onClick={() => disconnect.mutate()}
+              disabled={disconnect.isPending}
+              className="text-xs text-pawn-surface-500 hover:text-rose-400 transition-colors"
+            >
+              {disconnect.isPending ? "Disconnecting..." : "Disconnect"}
+            </button>
+          </div>
+        </div>
+      </div>
+    );
+  }
+
+  // ── Error / Expired ────────────────────────────────────────────────────────
+  if (conn && (conn.status === "error" || conn.status === "expired" || conn.status === "revoked")) {
+    const isError = conn.status === "error";
+    return (
+      <div className="border-t border-pawn-surface-800 bg-pawn-surface-950 px-4 py-3">
+        <div className="flex items-center justify-between">
+          <div className="flex items-center gap-2">
+            {isError ? (
+              <ShieldX size={14} className="text-rose-400" />
+            ) : (
+              <ShieldAlert size={14} className="text-amber-400" />
+            )}
+            <span className={`text-xs font-medium ${isError ? "text-rose-400" : "text-amber-400"}`}>
+              {conn.status === "error" ? "Error" : conn.status === "expired" ? "Expired" : "Revoked"}
+            </span>
+            {conn.errorMessage && (
+              <span className="text-xs text-pawn-surface-500 ml-1 truncate max-w-xs">
+                {conn.errorMessage}
+              </span>
+            )}
+          </div>
+          <button
+            onClick={() => connect.mutate()}
+            disabled={connect.isPending}
+            className="text-xs px-2.5 py-1 bg-pawn-gold-500 hover:bg-pawn-gold-400 text-pawn-surface-950 font-semibold rounded-button transition-colors disabled:opacity-50"
+          >
+            {connect.isPending ? <Loader size={11} className="animate-spin inline" /> : "Reconnect"}
+          </button>
+        </div>
+      </div>
+    );
+  }
+
+  // ── Disconnected (has config, no active connection) ────────────────────────
+  if (config) {
+    return (
+      <div className="border-t border-pawn-surface-800 bg-pawn-surface-950 px-4 py-3">
+        <div className="flex items-center justify-between">
+          <div className="flex items-center gap-2">
+            <Unplug size={14} className="text-pawn-surface-500" />
+            <span className="text-xs text-pawn-surface-400">OAuth configured</span>
+            <span className="text-xs text-pawn-surface-500 font-mono">{config.clientId}</span>
+          </div>
+          <button
+            onClick={() => connect.mutate()}
+            disabled={connect.isPending}
+            className="text-xs px-2.5 py-1 bg-pawn-gold-500 hover:bg-pawn-gold-400 text-pawn-surface-950 font-semibold rounded-button transition-colors disabled:opacity-50"
+          >
+            {connect.isPending ? <Loader size={11} className="animate-spin inline" /> : "Connect with OAuth"}
+          </button>
+        </div>
+        {saveError && (
+          <p className="text-xs text-rose-400 mt-2">{saveError}</p>
+        )}
+      </div>
+    );
+  }
+
+  // ── No OAuth Config ────────────────────────────────────────────────────────
+  return (
+    <div className="border-t border-pawn-surface-800 bg-pawn-surface-950 px-4 py-3">
+      <button
+        onClick={() => setConfigExpanded(!configExpanded)}
+        className="flex items-center gap-2 text-xs text-pawn-surface-400 hover:text-pawn-surface-300 transition-colors w-full"
+      >
+        {configExpanded ? <ChevronDown size={12} /> : <ChevronRight size={12} />}
+        <KeyRound size={12} />
+        <span>OAuth Configuration</span>
+      </button>
+
+      {configExpanded && (
+        <div className="mt-3 space-y-3">
+          <div>
+            <label className="text-xs text-pawn-surface-400 mb-1 block">Client ID</label>
+            <input
+              className="w-full bg-pawn-surface-800 border border-pawn-surface-700 rounded-button px-3 py-1.5 text-sm font-mono text-pawn-text-primary placeholder-pawn-surface-500 focus:outline-none focus:border-pawn-gold-500"
+              placeholder="your-client-id"
+              value={clientId}
+              onChange={(e) => setClientId(e.target.value)}
+            />
+          </div>
+          <div>
+            <label className="text-xs text-pawn-surface-400 mb-1 block">Client Secret</label>
+            <input
+              type="password"
+              className="w-full bg-pawn-surface-800 border border-pawn-surface-700 rounded-button px-3 py-1.5 text-sm font-mono text-pawn-text-primary placeholder-pawn-surface-500 focus:outline-none focus:border-pawn-gold-500"
+              placeholder="your-client-secret"
+              value={clientSecret}
+              onChange={(e) => setClientSecret(e.target.value)}
+            />
+          </div>
+          <div>
+            <label className="text-xs text-pawn-surface-400 mb-1 block">Scopes (comma-separated)</label>
+            <input
+              className="w-full bg-pawn-surface-800 border border-pawn-surface-700 rounded-button px-3 py-1.5 text-sm font-mono text-pawn-text-primary placeholder-pawn-surface-500 focus:outline-none focus:border-pawn-gold-500"
+              placeholder="read,write,admin"
+              value={scopes}
+              onChange={(e) => setScopes(e.target.value)}
+            />
+          </div>
+
+          {saveError && <p className="text-xs text-rose-400">{saveError}</p>}
+
+          <div className="flex justify-end">
+            <button
+              onClick={() => saveConfig.mutate()}
+              disabled={!clientId.trim() || saveConfig.isPending}
+              className="px-3 py-1.5 bg-pawn-gold-500 hover:bg-pawn-gold-400 text-pawn-surface-950 text-sm font-semibold rounded-button transition-colors disabled:opacity-40"
+            >
+              {saveConfig.isPending ? "Saving..." : "Save"}
+            </button>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}
+
+function formatRelativeTime(dateStr: string): string {
+  const date = new Date(dateStr);
+  const now = new Date();
+  const diffMs = date.getTime() - now.getTime();
+
+  if (diffMs < 0) return "Expired";
+
+  const diffMin = Math.floor(diffMs / 60000);
+  if (diffMin < 60) return `${diffMin}m`;
+  const diffHr = Math.floor(diffMin / 60);
+  if (diffHr < 24) return `${diffHr}h`;
+  const diffDays = Math.floor(diffHr / 24);
+  return `${diffDays}d`;
+}

--- a/ui/src/components/OAuthConnectionCard.tsx
+++ b/ui/src/components/OAuthConnectionCard.tsx
@@ -1,51 +1,33 @@
 import { useState } from "react";
 import { useMutation, useQueryClient } from "@tanstack/react-query";
-import { ChevronDown, ChevronRight, ShieldCheck, ShieldAlert, ShieldX, Unplug, Loader, KeyRound } from "lucide-react";
+import { ChevronDown, ChevronRight, ShieldCheck, ShieldAlert, ShieldX, Loader } from "lucide-react";
 import { api } from "../lib/api.ts";
 import type { ApiMcpServer } from "@pawn/shared";
 
+/**
+ * Shown inside McpServerRow expanded view for HTTP-based servers.
+ * Handles connected/error/expired states and the connect/disconnect actions.
+ * OAuth config (auth type, scopes, credentials) lives in AddMcpServerForm.
+ */
 export default function OAuthConnectionCard({ server }: { server: ApiMcpServer }) {
   const queryClient = useQueryClient();
-  const [configExpanded, setConfigExpanded] = useState(false);
-  const [clientId, setClientId] = useState("");
-  const [clientSecret, setClientSecret] = useState("");
-  const [scopes, setScopes] = useState("");
-  const [saveError, setSaveError] = useState("");
-
-  const saveConfig = useMutation({
-    mutationFn: () =>
-      api.updateMcpServer(server.id, {
-        oauthConfig: {
-          clientId: clientId.trim(),
-          hasClientSecret: !!clientSecret.trim(),
-          scopes: scopes.trim() ? scopes.split(",").map((s) => s.trim()).filter(Boolean) : undefined,
-        },
-        // Send the secret via a separate field the backend expects
-        ...(clientSecret.trim() ? { oauthClientSecret: clientSecret.trim() } as Record<string, string> : {}),
-      }),
-    onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: ["mcp-servers"] });
-      setSaveError("");
-    },
-    onError: (e: Error) => setSaveError(e.message),
-  });
+  const [error, setError] = useState("");
 
   const connect = useMutation({
     mutationFn: () => api.initiateOAuthConnect(server.id),
     onSuccess: (data) => {
       window.open(data.authUrl, "_blank");
     },
-    onError: (e: Error) => setSaveError(e.message),
+    onError: (e: Error) => setError(e.message),
   });
 
   const disconnect = useMutation({
     mutationFn: () => api.disconnectOAuth(server.id),
     onSuccess: () => queryClient.invalidateQueries({ queryKey: ["mcp-servers"] }),
-    onError: (e: Error) => setSaveError(e.message),
+    onError: (e: Error) => setError(e.message),
   });
 
   const conn = server.oauthConnection;
-  const config = server.oauthConfig;
 
   // ── Connected ──────────────────────────────────────────────────────────────
   if (conn && conn.status === "active") {
@@ -82,7 +64,7 @@ export default function OAuthConnectionCard({ server }: { server: ApiMcpServer }
     );
   }
 
-  // ── Error / Expired ────────────────────────────────────────────────────────
+  // ── Error / Expired / Revoked ──────────────────────────────────────────────
   if (conn && (conn.status === "error" || conn.status === "expired" || conn.status === "revoked")) {
     const isError = conn.status === "error";
     return (
@@ -111,19 +93,19 @@ export default function OAuthConnectionCard({ server }: { server: ApiMcpServer }
             {connect.isPending ? <Loader size={11} className="animate-spin inline" /> : "Reconnect"}
           </button>
         </div>
+        {error && <p className="text-xs text-rose-400 mt-2">{error}</p>}
       </div>
     );
   }
 
-  // ── Disconnected (has config, no active connection) ────────────────────────
-  if (config) {
+  // ── Disconnected (has OAuth config but no active connection) ────────────────
+  if (server.oauthConfig) {
     return (
       <div className="border-t border-pawn-surface-800 bg-pawn-surface-950 px-4 py-3">
         <div className="flex items-center justify-between">
           <div className="flex items-center gap-2">
-            <Unplug size={14} className="text-pawn-surface-500" />
-            <span className="text-xs text-pawn-surface-400">OAuth configured</span>
-            <span className="text-xs text-pawn-surface-500 font-mono">{config.clientId}</span>
+            <ShieldAlert size={14} className="text-pawn-surface-500" />
+            <span className="text-xs text-pawn-surface-400">OAuth configured — not connected</span>
           </div>
           <button
             onClick={() => connect.mutate()}
@@ -133,71 +115,13 @@ export default function OAuthConnectionCard({ server }: { server: ApiMcpServer }
             {connect.isPending ? <Loader size={11} className="animate-spin inline" /> : "Connect with OAuth"}
           </button>
         </div>
-        {saveError && (
-          <p className="text-xs text-rose-400 mt-2">{saveError}</p>
-        )}
+        {error && <p className="text-xs text-rose-400 mt-2">{error}</p>}
       </div>
     );
   }
 
-  // ── No OAuth Config ────────────────────────────────────────────────────────
-  return (
-    <div className="border-t border-pawn-surface-800 bg-pawn-surface-950 px-4 py-3">
-      <button
-        onClick={() => setConfigExpanded(!configExpanded)}
-        className="flex items-center gap-2 text-xs text-pawn-surface-400 hover:text-pawn-surface-300 transition-colors w-full"
-      >
-        {configExpanded ? <ChevronDown size={12} /> : <ChevronRight size={12} />}
-        <KeyRound size={12} />
-        <span>OAuth Configuration</span>
-      </button>
-
-      {configExpanded && (
-        <div className="mt-3 space-y-3">
-          <div>
-            <label className="text-xs text-pawn-surface-400 mb-1 block">Client ID</label>
-            <input
-              className="w-full bg-pawn-surface-800 border border-pawn-surface-700 rounded-button px-3 py-1.5 text-sm font-mono text-pawn-text-primary placeholder-pawn-surface-500 focus:outline-none focus:border-pawn-gold-500"
-              placeholder="your-client-id"
-              value={clientId}
-              onChange={(e) => setClientId(e.target.value)}
-            />
-          </div>
-          <div>
-            <label className="text-xs text-pawn-surface-400 mb-1 block">Client Secret</label>
-            <input
-              type="password"
-              className="w-full bg-pawn-surface-800 border border-pawn-surface-700 rounded-button px-3 py-1.5 text-sm font-mono text-pawn-text-primary placeholder-pawn-surface-500 focus:outline-none focus:border-pawn-gold-500"
-              placeholder="your-client-secret"
-              value={clientSecret}
-              onChange={(e) => setClientSecret(e.target.value)}
-            />
-          </div>
-          <div>
-            <label className="text-xs text-pawn-surface-400 mb-1 block">Scopes (comma-separated)</label>
-            <input
-              className="w-full bg-pawn-surface-800 border border-pawn-surface-700 rounded-button px-3 py-1.5 text-sm font-mono text-pawn-text-primary placeholder-pawn-surface-500 focus:outline-none focus:border-pawn-gold-500"
-              placeholder="read,write,admin"
-              value={scopes}
-              onChange={(e) => setScopes(e.target.value)}
-            />
-          </div>
-
-          {saveError && <p className="text-xs text-rose-400">{saveError}</p>}
-
-          <div className="flex justify-end">
-            <button
-              onClick={() => saveConfig.mutate()}
-              disabled={!clientId.trim() || saveConfig.isPending}
-              className="px-3 py-1.5 bg-pawn-gold-500 hover:bg-pawn-gold-400 text-pawn-surface-950 text-sm font-semibold rounded-button transition-colors disabled:opacity-40"
-            >
-              {saveConfig.isPending ? "Saving..." : "Save"}
-            </button>
-          </div>
-        </div>
-      )}
-    </div>
-  );
+  // No OAuth config — nothing to show (config lives in AddMcpServerForm / edit form)
+  return null;
 }
 
 function formatRelativeTime(dateStr: string): string {

--- a/ui/src/lib/api.ts
+++ b/ui/src/lib/api.ts
@@ -18,6 +18,7 @@ import type {
   ApiPipelineVersion,
   ApiBlueprintPreview,
   ApiModelWarning,
+  ApiOAuthConnectResponse,
 } from "@pawn/shared";
 
 const BASE = "/api";
@@ -271,6 +272,12 @@ export const api = {
   listMcpServerTools: (id: string) => request<ApiMcpTool[]>(`/mcp-servers/${id}/tools`),
   detectMcpEnv: (body: { transport: string; command?: string; args?: string[]; url?: string; name?: string }) =>
     request<{ detected: Array<{ name: string; required: boolean; description?: string; docsUrl?: string; detectedFrom: string }>; error?: string }>("/mcp-servers/detect-env", { method: "POST", body: JSON.stringify(body) }),
+
+  // OAuth
+  initiateOAuthConnect: (serverId: string) =>
+    request<ApiOAuthConnectResponse>(`/mcp-servers/${serverId}/oauth/connect`, { method: "POST" }),
+  disconnectOAuth: (serverId: string) =>
+    request<void>(`/mcp-servers/${serverId}/oauth/disconnect`, { method: "DELETE" }),
 
   // Models
   listModels: () => request<ApiModelEntry[]>("/models"),

--- a/ui/src/pages/Settings.tsx
+++ b/ui/src/pages/Settings.tsx
@@ -284,6 +284,16 @@ function AddMcpServerForm({ onCreated, onCancel }: { onCreated: () => void; onCa
   const [detectedVars, setDetectedVars] = useState<Array<{ name: string; required: boolean; description?: string; docsUrl?: string; detectedFrom: string; value: string }>>([]);
   const [detectionRan, setDetectionRan] = useState(false);
 
+  // OAuth config state
+  const [authType, setAuthType] = useState<"none" | "oauth">("none");
+  const [oauthScopes, setOauthScopes] = useState("");
+  const [useCustomCredentials, setUseCustomCredentials] = useState(false);
+  const [clientId, setClientId] = useState("");
+  const [clientSecret, setClientSecret] = useState("");
+  const [advancedOpen, setAdvancedOpen] = useState(false);
+
+  const isHttpTransport = transport === "sse" || transport === "streamable-http";
+
   const create = useMutation({
     mutationFn: () => {
       const parsedArgs = args.trim() ? args.trim().split(/\s+/) : [];
@@ -291,6 +301,17 @@ function AddMcpServerForm({ onCreated, onCancel }: { onCreated: () => void; onCa
       const parsedEnv = detectedVars.length > 0
         ? Object.fromEntries(detectedVars.filter(v => v.value).map(v => [v.name, v.value]))
         : parseKV(envVars);
+
+      // Build OAuth config if auth type is oauth
+      const oauthConfig = (isHttpTransport && authType === "oauth")
+        ? {
+            clientId: useCustomCredentials ? clientId.trim() : "default",
+            hasClientSecret: useCustomCredentials && !!clientSecret.trim(),
+            scopes: oauthScopes.trim() ? oauthScopes.trim().split(/\s+/) : undefined,
+            ...(useCustomCredentials && clientSecret.trim() ? { clientSecret: clientSecret.trim() } : {}),
+          } as any
+        : undefined;
+
       return api.createMcpServer({
         name,
         transport,
@@ -300,6 +321,7 @@ function AddMcpServerForm({ onCreated, onCancel }: { onCreated: () => void; onCa
         headers: parsedHeaders,
         env: parsedEnv,
         enabled: true,
+        ...(oauthConfig ? { oauthConfig } : {}),
       });
     },
     onSuccess: () => {
@@ -401,7 +423,7 @@ function AddMcpServerForm({ onCreated, onCancel }: { onCreated: () => void; onCa
           </>
         )}
 
-        {(transport === "sse" || transport === "streamable-http") && (
+        {isHttpTransport && (
           <>
             <div>
               <label className="text-xs text-pawn-surface-400 mb-1 block">URL</label>
@@ -412,12 +434,94 @@ function AddMcpServerForm({ onCreated, onCancel }: { onCreated: () => void; onCa
                 onChange={(e) => setUrl(e.target.value)}
               />
             </div>
+
+            {/* Authentication */}
+            <div className="border border-pawn-surface-700 rounded-card p-3 space-y-3">
+              <div>
+                <label className="text-xs font-medium text-pawn-text-secondary mb-1 block">Authentication</label>
+                <select
+                  className="w-full bg-pawn-surface-800 border border-pawn-surface-700 rounded-button px-3 py-1.5 text-sm text-pawn-text-primary focus:outline-none focus:border-pawn-gold-500"
+                  value={authType}
+                  onChange={(e) => setAuthType(e.target.value as "none" | "oauth")}
+                >
+                  <option value="none">None</option>
+                  <option value="oauth">OAuth</option>
+                </select>
+              </div>
+
+              {authType === "oauth" && (
+                <div className="border border-pawn-surface-700 rounded-card p-3 space-y-3">
+                  <button
+                    type="button"
+                    onClick={() => setAdvancedOpen(!advancedOpen)}
+                    className="flex items-center gap-1.5 text-xs text-pawn-surface-400 hover:text-pawn-surface-300 transition-colors"
+                  >
+                    {advancedOpen ? <ChevronDown size={12} /> : <ChevronRight size={12} />}
+                    Advanced
+                  </button>
+
+                  {advancedOpen && (
+                    <div className="space-y-3">
+                      <div>
+                        <label className="text-xs font-medium text-pawn-text-secondary mb-1 block">OAuth Scopes</label>
+                        <input
+                          className="w-full bg-pawn-surface-800 border border-pawn-surface-700 rounded-button px-3 py-1.5 text-sm font-mono text-pawn-text-primary placeholder-pawn-surface-500 focus:outline-none focus:border-pawn-gold-500"
+                          placeholder="mcp:* or custom scopes separated by spaces"
+                          value={oauthScopes}
+                          onChange={(e) => setOauthScopes(e.target.value)}
+                        />
+                        <p className="text-xs text-pawn-surface-500 mt-1">Default: mcp:* (space-separated for multiple scopes)</p>
+                      </div>
+
+                      <div>
+                        <label className="flex items-center gap-2 cursor-pointer">
+                          <input
+                            type="checkbox"
+                            checked={useCustomCredentials}
+                            onChange={(e) => setUseCustomCredentials(e.target.checked)}
+                            className="rounded border-pawn-surface-600 bg-pawn-surface-800 text-pawn-gold-500 focus:ring-pawn-gold-500"
+                          />
+                          <span className="text-sm text-pawn-text-secondary">Use custom OAuth credentials</span>
+                        </label>
+                        <p className="text-xs text-pawn-surface-500 mt-1 ml-6">Leave unchecked to use the server's default OAuth flow</p>
+                      </div>
+
+                      {useCustomCredentials && (
+                        <div className="space-y-3 ml-6">
+                          <div>
+                            <label className="text-xs text-pawn-surface-400 mb-1 block">Client ID</label>
+                            <input
+                              className="w-full bg-pawn-surface-800 border border-pawn-surface-700 rounded-button px-3 py-1.5 text-sm font-mono text-pawn-text-primary placeholder-pawn-surface-500 focus:outline-none focus:border-pawn-gold-500"
+                              placeholder="your-client-id"
+                              value={clientId}
+                              onChange={(e) => setClientId(e.target.value)}
+                            />
+                          </div>
+                          <div>
+                            <label className="text-xs text-pawn-surface-400 mb-1 block">Client Secret</label>
+                            <input
+                              type="password"
+                              className="w-full bg-pawn-surface-800 border border-pawn-surface-700 rounded-button px-3 py-1.5 text-sm font-mono text-pawn-text-primary placeholder-pawn-surface-500 focus:outline-none focus:border-pawn-gold-500"
+                              placeholder="your-client-secret"
+                              value={clientSecret}
+                              onChange={(e) => setClientSecret(e.target.value)}
+                            />
+                          </div>
+                        </div>
+                      )}
+                    </div>
+                  )}
+                </div>
+              )}
+            </div>
+
+            {/* Custom Headers */}
             <div>
-              <label className="text-xs text-pawn-surface-400 mb-1 block">Headers (KEY=VALUE, one per line)</label>
+              <label className="text-xs text-pawn-surface-400 mb-1 block">Custom Headers (KEY=VALUE, one per line)</label>
               <textarea
                 className="w-full bg-pawn-surface-800 border border-pawn-surface-700 rounded-button px-3 py-1.5 text-sm font-mono text-pawn-text-primary placeholder-pawn-surface-500 focus:outline-none focus:border-pawn-gold-500 resize-none"
                 rows={2}
-                placeholder={"Authorization=Bearer sk-...\nX-Custom-Header=value"}
+                placeholder={"X-Custom-Header=value"}
                 value={headers}
                 onChange={(e) => setHeaders(e.target.value)}
               />

--- a/ui/src/pages/Settings.tsx
+++ b/ui/src/pages/Settings.tsx
@@ -262,7 +262,7 @@ function McpServerRow({ server }: { server: ApiMcpServer }) {
         </div>
       )}
 
-      {expanded && (server.transport === "sse" || server.transport === "streamable-http") && (
+      {(server.transport === "sse" || server.transport === "streamable-http") && server.oauthConfig && (
         <OAuthConnectionCard server={server} />
       )}
     </div>

--- a/ui/src/pages/Settings.tsx
+++ b/ui/src/pages/Settings.tsx
@@ -1,10 +1,11 @@
 import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
 import { Bot, Server, Plus, X, Trash2, ChevronDown, ChevronRight, Check, AlertCircle, Loader, Cable, Sun, Moon, Monitor, Palette } from "lucide-react";
-import { useState } from "react";
+import { useState, useEffect } from "react";
 import { api } from "../lib/api.ts";
 import { useTheme } from "../context/ThemeContext.tsx";
 import ModelSelector from "../components/ModelSelector.tsx";
 import PageHeader from "../components/PageHeader.tsx";
+import OAuthConnectionCard from "../components/OAuthConnectionCard.tsx";
 import type { ApiMcpServer, ApiMcpTool } from "@pawn/shared";
 
 // ── Appearance ───────────────────────────────────────────────────────────────
@@ -259,6 +260,10 @@ function McpServerRow({ server }: { server: ApiMcpServer }) {
             )}
           </div>
         </div>
+      )}
+
+      {expanded && (server.transport === "sse" || server.transport === "streamable-http") && (
+        <OAuthConnectionCard server={server} />
       )}
     </div>
   );
@@ -799,9 +804,49 @@ function AddProviderForm({
 // ── Page ──────────────────────────────────────────────────────────────────────
 
 export default function Settings() {
+  const [oauthMessage, setOauthMessage] = useState<{ type: "success" | "error"; text: string } | null>(null);
+
+  useEffect(() => {
+    const params = new URLSearchParams(window.location.search);
+    const oauthStatus = params.get("oauth");
+    if (oauthStatus === "success") {
+      setOauthMessage({ type: "success", text: "OAuth connection established successfully." });
+      window.history.replaceState({}, "", window.location.pathname);
+    } else if (oauthStatus === "error") {
+      const msg = params.get("message") || "OAuth connection failed.";
+      setOauthMessage({ type: "error", text: msg });
+      window.history.replaceState({}, "", window.location.pathname);
+    }
+  }, []);
+
   return (
     <div className="p-4 sm:p-6 lg:p-10 max-w-4xl pt-14 lg:pt-10">
       <PageHeader title="Settings" />
+
+      {oauthMessage && (
+        <div
+          className={`mb-4 px-4 py-3 rounded-card border text-sm flex items-center justify-between ${
+            oauthMessage.type === "success"
+              ? "bg-emerald-900/20 border-emerald-800/30 text-emerald-300"
+              : "bg-rose-900/20 border-rose-800/30 text-rose-300"
+          }`}
+        >
+          <div className="flex items-center gap-2">
+            {oauthMessage.type === "success" ? (
+              <Check size={14} className="text-emerald-400" />
+            ) : (
+              <AlertCircle size={14} className="text-rose-400" />
+            )}
+            {oauthMessage.text}
+          </div>
+          <button
+            onClick={() => setOauthMessage(null)}
+            className="text-pawn-surface-400 hover:text-pawn-surface-300 transition-colors"
+          >
+            <X size={14} />
+          </button>
+        </div>
+      )}
 
       <AppearanceSection />
       <ActiveModelsSection />


### PR DESCRIPTION
## Summary

Adds first-class OAuth 2.1 authorization support for HTTP-based MCP servers, compliant with the [MCP Authorization specification](https://spec.modelcontextprotocol.io/specification/draft/basic/authorization/).

- **OAuth lifecycle**: Discovery → Authorization Code + PKCE → Token exchange → Encrypted storage → Bearer token injection → Background refresh
- **Leverages MCP SDK**: Implements `OAuthClientProvider` interface from `@modelcontextprotocol/sdk` — the SDK handles protocol compliance (RFC 9728, 8414, 8707)
- **Token encryption at rest**: AES-256-GCM with auto-managed key (`DATA_DIR/oauth-encryption.key` or `OAUTH_ENCRYPTION_KEY` env var)
- **Background refresh**: 60-second polling refreshes tokens 5 minutes before expiry
- **Frontend UI**: OAuthConnectionCard in Settings with configure, connect, status, and disconnect flows

### Implementation units
1. Token encryption service (AES-256-GCM)
2. Database schema (`oauth_connections`, `oauth_pending_flows` tables, `oauth_config` on `mcp_servers`)
3. Shared API types (`ApiOAuthConnection`, `ApiOAuthConfig`, `ApiOAuthConnectResponse`)
4. `PawnOAuthClientProvider` implementing SDK's `OAuthClientProvider` interface
5. OAuth flow service + API routes (`/connect`, `/callback`, `/disconnect`, `/status`)
6. MCP client integration (pass `authProvider` to HTTP transports)
7. Background token refresh polling
8. Frontend OAuth UI (OAuthConnectionCard component)
9. Server startup/shutdown lifecycle wiring

### Key decisions
- OAuth 2.1 only (per MCP spec), HTTP transports only (stdio uses env credentials per spec)
- System-wide connections (one per MCP server, not per-user)
- User-provided client credentials (no pre-shipped provider configs)
- PKCE required (S256, handled by SDK)

Closes #64

## Test plan
- [ ] Server tests pass (206 tests, all passing)
- [ ] TypeScript compiles clean across all packages
- [ ] Full build passes (server, UI, CLI, MCP packages)
- [ ] Manual test: configure OAuth client credentials for an MCP server in Settings
- [ ] Manual test: initiate OAuth connect flow, complete authorization, verify connected status
- [ ] Manual test: verify Bearer token injection when connecting to OAuth-enabled MCP server
- [ ] Manual test: verify token refresh works before expiry
- [ ] Manual test: disconnect OAuth and verify cleanup

## Post-Deploy Monitoring & Validation
- **Log queries**: `[OAuth]`, `[oauth-refresh]` prefixes in server logs
- **Healthy signals**: `[OAuth] Encryption key loaded from...`, `[OAuth] Token refresh polling started`, successful token refreshes logged
- **Failure signals**: `[oauth-refresh] Failed to refresh` errors, connections stuck in `error` status
- **Validation window**: Monitor first 24 hours after deploy for refresh cycle stability
- **Rollback trigger**: If encryption key initialization fails at startup (server won't start — fail-fast behavior)